### PR TITLE
Remove a couple of Range allocations

### DIFF
--- a/lib/pagy.rb
+++ b/lib/pagy.rb
@@ -28,7 +28,7 @@ class Pagy ; VERSION = '0.7.0'
       instance_variable_set(:"@#{k}", @vars.delete(k).to_i)               # set instance variables
     end
     @pages  = @last = [(@count.to_f / @items).ceil, 1].max                # cardinal and ordinal meanings
-    (1..@last).cover?(@page) || raise(OutOfRangeError, "expected :page in 1..#{@last}; got #{@page.inspect}")
+    @page >= 1 && @page <= @last or raise(OutOfRangeError, "expected :page in 1..#{@last}; got #{@page.inspect}")
     @offset = @items * (@page - 1) + @outset                              # pagination offset + outset (initial offset)
     @items  = @count % @items if @page == @last                           # adjust items for last page
     @from   = @count == 0 ? 0 : @offset+1 - @outset                       # page begins from item
@@ -39,7 +39,7 @@ class Pagy ; VERSION = '0.7.0'
 
   # return the array of page numbers and :gap items e.g. [1, :gap, 7, 8, "9", 10, 11, :gap, 36]
   def series(size=@vars[:size])
-    (0..3).each{|i| (size[i]>=0 rescue nil) or raise(ArgumentError, "expected 4 items >= 0 in :size; got #{size.inspect}")}
+    4.times{|i| (size[i]>=0 rescue nil) or raise(ArgumentError, "expected 4 items >= 0 in :size; got #{size.inspect}")}
     series = []
     [*0..size[0], *@page-size[1]..@page+size[2], *@last-size[3]+1..@last+1].sort!.each_cons(2) do |a, b|
       if    a<0 || a==b || a>@last                                        # skip out of range and duplicates


### PR DESCRIPTION
This gem seems to be (proudly) optimized for speed and few object allocations, so I figure it’s ok to open a PR for removing even a few superfluous `Range` instantiations :-)