### PR TITLE
URIs are always joined with forward slash

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,7 @@ GEM
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
+    rack (2.0.5)
     rake (10.5.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -273,6 +274,7 @@ DEPENDENCIES
   memory_profiler
   minitest (~> 5.0)
   pagy!
+  rack
   rake (~> 10.0)
   slim
 

--- a/lib/pagy/frontend.rb
+++ b/lib/pagy/frontend.rb
@@ -34,7 +34,7 @@ class Pagy
 
     # this works with all Rack-based frameworks (Sinatra, Padrino, Rails, ...)
     def pagy_url_for(n)
-      url    = File.join(request.script_name.to_s, request.path_info)
+      url    = request.path
       params = request.GET.merge('page'.freeze => n.to_s)
       url << '?' << Rack::Utils.build_nested_query(pagy_get_params(params))
     end

--- a/pagy.gemspec
+++ b/pagy.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler',  '~> 1.16'
   s.add_development_dependency 'rake',     '~> 10.0'
   s.add_development_dependency 'minitest', '~> 5.0'
+  s.add_development_dependency 'rack'
   s.add_development_dependency 'slim'
   s.add_development_dependency 'haml'
   s.add_development_dependency 'benchmark-ips'

--- a/test/frontend_test.rb
+++ b/test/frontend_test.rb
@@ -1,0 +1,72 @@
+require 'test_helper'
+require 'rack'
+
+class FrontendTest < Minitest::Test
+
+  class TestView
+    include Pagy::Frontend
+
+    def request
+      Rack::Request.new('SCRIPT_NAME' => '/foo')
+    end
+  end
+
+  def setup
+    @frontend = TestView.new
+    @array = (1..103).to_a.extend(Pagy::Array::PageMethod)
+  end
+
+  def test_pagy_nav_page_1
+    pagy, paged = @array.pagy(1)
+
+    assert_equal(
+      '<nav class="pagy-nav pagination" role="navigation" aria-label="pager">' \
+      '<span class="page prev disabled">&lsaquo;&nbsp;Prev</span> ' \
+      '<span class="page active">1</span> ' \
+      '<span class="page"><a href="/foo?page=2" rel="next">2</a></span> ' \
+      '<span class="page"><a href="/foo?page=3">3</a></span> ' \
+      '<span class="page"><a href="/foo?page=4">4</a></span> ' \
+      '<span class="page"><a href="/foo?page=5">5</a></span> ' \
+      '<span class="page"><a href="/foo?page=6">6</a></span> ' \
+      '<span class="page next"><a href="/foo?page=2" rel="next" aria-label="next">Next&nbsp;&rsaquo;</a></span>' \
+      '</nav>',
+      @frontend.pagy_nav(pagy)
+    )
+  end
+
+  def test_pagy_nav_page_3
+    pagy, paged = @array.pagy(3)
+
+    assert_equal(
+      '<nav class="pagy-nav pagination" role="navigation" aria-label="pager">' \
+      '<span class="page prev"><a href="/foo?page=2" rel="prev" aria-label="previous">&lsaquo;&nbsp;Prev</a></span> ' \
+      '<span class="page"><a href="/foo?page=1">1</a></span> ' \
+      '<span class="page"><a href="/foo?page=2" rel="prev">2</a></span> ' \
+      '<span class="page active">3</span> ' \
+      '<span class="page"><a href="/foo?page=4" rel="next">4</a></span> ' \
+      '<span class="page"><a href="/foo?page=5">5</a></span> ' \
+      '<span class="page"><a href="/foo?page=6">6</a></span> ' \
+      '<span class="page next"><a href="/foo?page=4" rel="next" aria-label="next">Next&nbsp;&rsaquo;</a></span>' \
+      '</nav>',
+      @frontend.pagy_nav(pagy)
+    )
+  end
+
+  def test_pagy_nav_page_6
+    pagy, paged = @array.pagy(6)
+
+    assert_equal(
+      '<nav class="pagy-nav pagination" role="navigation" aria-label="pager">' \
+      '<span class="page prev"><a href="/foo?page=5" rel="prev" aria-label="previous">&lsaquo;&nbsp;Prev</a></span> ' \
+      '<span class="page"><a href="/foo?page=1">1</a></span> ' \
+      '<span class="page"><a href="/foo?page=2">2</a></span> ' \
+      '<span class="page"><a href="/foo?page=3">3</a></span> ' \
+      '<span class="page"><a href="/foo?page=4">4</a></span> ' \
+      '<span class="page"><a href="/foo?page=5" rel="prev">5</a></span> ' \
+      '<span class="page active">6</span> ' \
+      '<span class="page next disabled">Next&nbsp;&rsaquo;</span>' \
+      '</nav>',
+      @frontend.pagy_nav(pagy)
+    )
+  end
+end


### PR DESCRIPTION
`File.join` might use backslash on e.g. Windows - URL paths are not File paths.

According to Rack specification:

 - The `SCRIPT_NAME`, if non-empty, must start with `/`
 - The `PATH_INFO`, if non-empty, must start with `/`
 - One of `SCRIPT_NAME` or `PATH_INFO` must be set. `PATH_INFO` should be `/` if
   `SCRIPT_NAME` is empty. `SCRIPT_NAME` never should be `/`, but instead be
   empty.

And in fact Rack provides this handy `#path` method for exactly this purpose: https://github.com/rack/rack/blob/42e48013dd1b6dbd/lib/rack/request.rb#L406-L408
