### PR TITLE
Only use and/or keywords for control flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ This extra adds an alternative pagination UI that joins the pagination feature w
 ## Useful Links
 
 - [Documentation](https://ddnexus.github.io/pagy/index)
-- [Pagination Comparison App](http://github.com/ddnexus/pagination-comparison)
+- [Gems Comparison](https://ddnexus.github.io/pagination-comparison/gems.html)
+- [Pagination Comparison App Repository](http://github.com/ddnexus/pagination-comparison)
 
 ## Help Wanted
 

--- a/docs/pagy-extras/responsive.md
+++ b/docs/pagy-extras/responsive.md
@@ -46,14 +46,14 @@ This extra is composed of 2 small files:
 ### :breakpoints
 
 The `:breakpoint` variable is a pagy variable added by the `responsive` extra: it allows you to control how the page links will get shown at different widths. It is a hash where the keys are integers representing the breakpoint widths in pixels and the values are the pagy `:size` variables to be applied for that width.
-
  For example:
 
 ```ruby
 Pagy::VARS[:breakpoints] = {0 => [1,2,2,1], 450 => [3,4,4,3], 750 => [4,5,5,4]}
 ```
 
-The above statement means that from `0` to `450` pixels width, pagy will use the `[1,2,2,1]` size, from `450` to `750` it will use the `[3,4,4,3]` size and over `750` it will use the `[4,5,5,4]` size.
+The above statement means that from `0` to `450` pixels width, pagy will use the `[1,2,2,1]` size, from `450` to `750` it will use the `[3,4,4,3]` size and over `750` it will use the `[4,5,5,4]` size. (Read more about the `:size` variable in the [How to control the page links](../how-to.md#control-the-page-links) section)
+
 
 **IMPORTANT**: You can set any number of breakpoints with any arbitrary width and size. The only constraint is that the `:breakpoints` hash must contain always the `0` size. An `ArgumentError` exception will be raises if it is missing.
 

--- a/lib/pagy.rb
+++ b/lib/pagy.rb
@@ -22,7 +22,7 @@ class Pagy ; VERSION = '0.7.0'
 
   # merge and validate the options, do some simple aritmetic and set the instance variables
   def initialize(vars)
-    @vars = VARS.merge(vars.delete_if{|k,v| v.nil? or v == '' })          # default vars + cleaned instance vars
+    @vars = VARS.merge(vars.delete_if{|k,v| v.nil? || v == '' })          # default vars + cleaned instance vars
     { count:0, items:1, outset:0, page:1 }.each do |k,min|                # validate core variables
       (@vars[k] && @vars[k].to_i >= min) or raise(ArgumentError, "expected :#{k} >= #{min}; got #{@vars[k].inspect}")
       instance_variable_set(:"@#{k}", @vars.delete(k).to_i)               # set instance variables


### PR DESCRIPTION
Using `and` and `or` for anything other than control flow has too often lead to subtle bugs.