### PR TITLE
style cleanup

### DIFF
--- a/lib/pagy/frontend.rb
+++ b/lib/pagy/frontend.rb
@@ -33,14 +33,14 @@ class Pagy
 
 
     # this works with all Rack-based frameworks (Sinatra, Padrino, Rails, ...)
-    def pagy_url_for(n)
-      params = request.GET.merge('page'.freeze => n.to_s)
+    def pagy_url_for(page)
+      params = request.GET.merge('page'.freeze => page.to_s)
       "#{request.path}?#{Rack::Utils.build_nested_query(pagy_get_params(params))}"
     end
 
 
     # sub-method called only by #pagy_url_for: here for easy customization of params by overriding
-    def pagy_get_params(p) p end
+    def pagy_get_params(params) params end
 
 
     MARKER = "-pagy-#{'pagy'.hash}-".freeze
@@ -59,7 +59,7 @@ class Pagy
     # this file will get autoloaded, so environment constants like ::I18n will be already set
     if I18N[:gem] || I18N[:gem].nil? && defined?(I18n)
       I18n.load_path << I18N[:file]
-      def pagy_t(*a) I18n.t(*a) end
+      def pagy_t(*args) I18n.t(*args) end
     else
       require 'yaml'
       # load data from the first locale in the file

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -7,7 +7,7 @@ class I18nTest < Minitest::Test
   end
 
   def setup
-    @I18n = TestI18n.new # rubocop:disable Naming/VariableName TODO rename
+    @i18n = TestI18n.new
   end
 
   def test_data
@@ -16,35 +16,35 @@ class I18nTest < Minitest::Test
   end
 
   def test_translation
-    assert_equal "&lsaquo;&nbsp;Prev", @I18n.pagy_t('pagy.nav.prev')
+    assert_equal "&lsaquo;&nbsp;Prev", @i18n.pagy_t('pagy.nav.prev')
 
-    assert_equal "items", @I18n.pagy_t('pagy.info.item_name', count: 0)
-    assert_equal "item", @I18n.pagy_t('pagy.info.item_name', count: 1)
-    assert_equal "items", @I18n.pagy_t('pagy.info.item_name', count: 10)
+    assert_equal "items", @i18n.pagy_t('pagy.info.item_name', count: 0)
+    assert_equal "item", @i18n.pagy_t('pagy.info.item_name', count: 1)
+    assert_equal "items", @i18n.pagy_t('pagy.info.item_name', count: 10)
 
     assert_equal "No %{item_name} found",
-                 @I18n.pagy_t('pagy.info.single_page', count: 0)
+                 @i18n.pagy_t('pagy.info.single_page', count: 0)
     assert_equal "Displaying <b>1</b> %{item_name}",
-                 @I18n.pagy_t('pagy.info.single_page', count: 1)
+                 @i18n.pagy_t('pagy.info.single_page', count: 1)
     assert_equal "Displaying <b>all 10</b> %{item_name}",
-                 @I18n.pagy_t('pagy.info.single_page', count: 10)
+                 @i18n.pagy_t('pagy.info.single_page', count: 10)
     assert_equal "Displaying %{item_name} <b>%{from}-%{to}</b> of <b>10</b> in total",
-                 @I18n.pagy_t('pagy.info.multiple_pages', count: 10)
+                 @i18n.pagy_t('pagy.info.multiple_pages', count: 10)
   end
 
   def test_missing
-    assert_equal 'translation missing: "pagy.nav.not_here"', @I18n.pagy_t('pagy.nav.not_here')
+    assert_equal 'translation missing: "pagy.nav.not_here"', @i18n.pagy_t('pagy.nav.not_here')
   end
 
   def test_render_info_no_118n_key
     pagy = Pagy.new count: 0
-    assert_equal "No items found", @I18n.pagy_info(pagy)
+    assert_equal "No items found", @i18n.pagy_info(pagy)
     pagy = Pagy.new count: 1
-    assert_equal "Displaying <b>1</b> item", @I18n.pagy_info(pagy)
+    assert_equal "Displaying <b>1</b> item", @i18n.pagy_info(pagy)
     pagy = Pagy.new count: 13
-    assert_equal "Displaying <b>all 13</b> items", @I18n.pagy_info(pagy)
+    assert_equal "Displaying <b>all 13</b> items", @i18n.pagy_info(pagy)
     pagy = Pagy.new count: 100, page: 3
-    assert_equal "Displaying items <b>41-60</b> of <b>100</b> in total", @I18n.pagy_info(pagy)
+    assert_equal "Displaying items <b>41-60</b> of <b>100</b> in total", @i18n.pagy_info(pagy)
   end
 
   def test_render_info_with_existing_118n_key
@@ -52,13 +52,13 @@ class I18nTest < Minitest::Test
                                                              'one'   => 'Product',
                                                              'other' => 'Products' }
     pagy = Pagy.new count: 0, item_path: 'pagy.info.product'
-    assert_equal "No Products found", @I18n.pagy_info(pagy)
+    assert_equal "No Products found", @i18n.pagy_info(pagy)
     pagy = Pagy.new count: 1, item_path: 'pagy.info.product'
-    assert_equal "Displaying <b>1</b> Product", @I18n.pagy_info(pagy)
+    assert_equal "Displaying <b>1</b> Product", @i18n.pagy_info(pagy)
     pagy = Pagy.new count: 13, item_path: 'pagy.info.product'
-    assert_equal "Displaying <b>all 13</b> Products", @I18n.pagy_info(pagy)
+    assert_equal "Displaying <b>all 13</b> Products", @i18n.pagy_info(pagy)
     pagy = Pagy.new count: 100, page: 3, item_path: 'pagy.info.product'
-    assert_equal "Displaying Products <b>41-60</b> of <b>100</b> in total", @I18n.pagy_info(pagy)
+    assert_equal "Displaying Products <b>41-60</b> of <b>100</b> in total", @i18n.pagy_info(pagy)
   end
 
 end


### PR DESCRIPTION
 - uppercase instance vars are uncommon, so avoiding that
 - using readable argument names (also helps with code autocomplete for end-users)

@ddnexus
