### PR TITLE
use actionable code coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'benchmark-ips'
 gem 'kalibera'
 gem 'memory_profiler'
 gem 'rubocop', '~> 0.55.0' # needs to be fixed since it constantly adds new cops
+gem 'single_cov'
 
 
 gem "github-pages", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,7 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    single_cov (1.0.3)
     slim (3.0.9)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
@@ -285,6 +286,7 @@ DEPENDENCIES
   rack
   rake (~> 10.0)
   rubocop (~> 0.55.0)
+  single_cov
   slim
 
 BUNDLED WITH

--- a/test/pagy/frontend_test.rb
+++ b/test/pagy/frontend_test.rb
@@ -1,8 +1,9 @@
 require_relative '../test_helper'
 require 'rack'
 
-describe Pagy::Frontend do
+SingleCov.covered!
 
+describe Pagy::Frontend do
   class TestView
     include Pagy::Frontend
 
@@ -71,6 +72,44 @@ describe Pagy::Frontend do
       frontend.pagy_nav(pagy)
       )
     end
+
+    def test_pagy_nav_page_10
+      @array = (1..1000).to_a.extend(Pagy::Array::PageMethod)
+      pagy, _ = @array.pagy(10)
+
+      assert_equal(
+        '<nav class="pagy-nav pagination" role="navigation" aria-label="pager">' \
+          '<span class="page prev"><a href="/foo?page=9" rel="prev" aria-label="previous">&lsaquo;&nbsp;Prev</a></span> ' \
+          '<span class="page"><a href="/foo?page=1">1</a></span> ' \
+          '<span class="page gap">&hellip;</span> ' \
+          '<span class="page"><a href="/foo?page=6">6</a></span> ' \
+          '<span class="page"><a href="/foo?page=7">7</a></span> ' \
+          '<span class="page"><a href="/foo?page=8">8</a></span> ' \
+          '<span class="page"><a href="/foo?page=9" rel="prev">9</a></span> ' \
+          '<span class="page active">10</span> ' \
+          '<span class="page"><a href="/foo?page=11" rel="next">11</a></span> ' \
+          '<span class="page"><a href="/foo?page=12">12</a></span> ' \
+          '<span class="page"><a href="/foo?page=13">13</a></span> ' \
+          '<span class="page"><a href="/foo?page=14">14</a></span> ' \
+          '<span class="page gap">&hellip;</span> ' \
+          '<span class="page"><a href="/foo?page=50">50</a></span> ' \
+          '<span class="page next"><a href="/foo?page=11" rel="next" aria-label="next">Next&nbsp;&rsaquo;</a></span></nav>',
+        frontend.pagy_nav(pagy)
+      )
+    end
+
+    def test_link_extras
+      pagy, _ = @array.pagy(1, link_extra: "X")
+      frontend.pagy_nav(pagy).must_include '?page=2" X rel'
+    end
+  end
+
+  describe "#pagy_link_proc" do
+    it "renders with extras" do
+      @array = (1..103).to_a.extend(Pagy::Array::PageMethod)
+      pagy, _ = @array.pagy(1)
+      frontend.pagy_link_proc(pagy, "X").call(1).must_equal '<a href="/foo?page=1" X>1</a>'
+    end
   end
 
   describe "#pagy_t" do
@@ -125,5 +164,4 @@ describe Pagy::Frontend do
       assert_equal "Displaying Products <b>41-60</b> of <b>100</b> in total", frontend.pagy_info(pagy)
     end
   end
-
 end

--- a/test/pagy_test.rb
+++ b/test/pagy_test.rb
@@ -1,5 +1,7 @@
 require_relative 'test_helper'
 
+SingleCov.covered!
+
 describe Pagy do
   let(:pagy) { Pagy.new count: 100, page: 4 }
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,8 @@
+require 'bundler/setup'
+
+require 'single_cov'
+SingleCov.setup :minitest
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require 'pagy'
 require_relative 'array'


### PR DESCRIPTION
for https://github.com/ddnexus/pagy/issues/13

a rough cut of what it could look like ...

tests will now fail when coverage gaps (also branch coverage) are introduces:

```
# Running:

...
Finished in 0.009591s, 312.7932 runs/s, 312.7932 assertions/s.

3 runs, 3 assertions, 0 failures, 0 errors, 0 skips
lib/pagy/frontend.rb new uncovered lines introduced (10 current vs 0 configured)
Lines missing coverage:
lib/pagy/frontend.rb:20
lib/pagy/frontend.rb:31
lib/pagy/frontend.rb:32
lib/pagy/frontend.rb:33
lib/pagy/frontend.rb:53:64-53:75
lib/pagy/frontend.rb:53:107-53:116
lib/pagy/frontend.rb:69
lib/pagy/frontend.rb:70
lib/pagy/frontend.rb:71
lib/pagy/frontend.rb:72
```

to get this completely working another set of best-practices should be followed:
 - 1 test per lib file (integration tests can be added too)
 - structure test to mirror lib structure
 - do not load all of pagy when loading the gemspec since that would be before coverage reporting can start

... they should be improvements to the discoverability of tests and good coverage on their own, so we can start with them before adding coverage or merge this and then change the structure / improve coverage in parallel

/cc @bquorning @ddnexus @gamafranco 