### PR TITLE
Enable support for return key inside Pagy compact input

### DIFF
--- a/lib/pagy/extras/javascripts/pagy-compact.js
+++ b/lib/pagy/extras/javascripts/pagy-compact.js
@@ -11,5 +11,12 @@ function PagyCompact(id, marker, page){
     }
   };
 
-  input.addEventListener("focusout", this.go);
+  // jump to page number from input when input looses focus
+  input.addEventListener('focusout', this.go)
+  // … and when pressing enter inside input
+  input.addEventListener('keyup', function (e) {
+    if (event.which === 13) {
+      this.go()
+    }
+  }.bind(this))
 }


### PR DESCRIPTION
This small PR adds support for the return key inside the compact navs input:

![img_8687](https://user-images.githubusercontent.com/3188392/41196854-1e684f92-6c4b-11e8-8dea-0a436f2ab5d0.jpeg)

On mobile, iOS in this example, previously one had to tap "Done" in the right corner directly above the keyboard (or otherwise loose input focus) to call the `go()` function and jump to the page number specified inside the input. Now pressing `Return` (right bottom corner) also works, obviously on desktop machines too.