### PR TITLE
Fix typo in :page_param configuration

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -190,7 +190,7 @@ That will explicitly set the `:page` variable, overriding the default behavior (
 
 ## Customizing the page param
 
-Pagy uses the `:page_param` variable to determine the param it should get the page number from and create the URL for. Its default is set as `Pagy::VARS = :page`, hence it will get the page number from the `params[:page]` and will create page URLs like `./?page=3` by default.
+Pagy uses the `:page_param` variable to determine the param it should get the page number from and create the URL for. Its default is set as `Pagy::VARS[:page_param] = :page`, hence it will get the page number from the `params[:page]` and will create page URLs like `./?page=3` by default.
 
 You may want to customize that, for example to make it more readable in your language, or becuse you need to paginate different collections in the same action. Depending on the scope of the customization, you have a couple of options:
 


### PR DESCRIPTION
The documentation example for configuring :page_param assigns a symbol
directly to Pagy::VARS.  It should probably assign a symbol to a slot
on Pagy::VARS instead.

Update the documention to assign to "Pagy::VARS[:page_param]" instead.