### PR TITLE
Add support for counting grouped collections

### DIFF
--- a/lib/pagy/backend.rb
+++ b/lib/pagy/backend.rb
@@ -16,9 +16,10 @@ class Pagy
 
     # Sub-method called only by #pagy: here for easy customization of variables by overriding
     def pagy_get_vars(collection, vars)
-      # Return the merged variables to initialize the Pagy object
-      { count: collection.count(:all),        # works with AR, but may not work with other ORMs
-        page:  params[vars[:page_param]||VARS[:page_param]] }.merge!(vars)
+      count = collection.count(:all)
+      count = count.count if count.respond_to?(:count) # e.g. AR .group returns an OrderdHash that responds to #count
+      # return the merged variables to initialize the pagy object
+      { count: count, page: params[vars[:page_param] || VARS[:page_param]] }.merge!(vars)
     end
 
     # Sub-method called only by #pagy: here for easy customization of record-extraction by overriding

--- a/test/pagy/backend_test.rb
+++ b/test/pagy/backend_test.rb
@@ -4,7 +4,6 @@ SingleCov.covered!
 
 describe Pagy::Backend do
 
-
   let(:backend) { TestController.new }
 
   describe "#pagy" do
@@ -54,6 +53,20 @@ describe Pagy::Backend do
     end
 
     def test_pagy_get_vars_with_vars
+      vars   = {page: 2, items: 10, link_extra: 'X'}
+      merged = backend.send :pagy_get_vars, @collection, vars
+      assert_includes(merged.keys, :count)
+      assert_includes(merged.keys, :page)
+      assert_includes(merged.keys, :items)
+      assert_includes(merged.keys, :link_extra)
+      assert_equal(1000, merged[:count])
+      assert_equal(2, merged[:page])
+      assert_equal(10, merged[:items])
+      assert_equal('X', merged[:link_extra])
+    end
+
+    def test_pagy_get_vars_with_grouped_collection
+      @collection = GroupedCollection.new((1..1000).to_a)
       vars   = {page: 2, items: 10, link_extra: 'X'}
       merged = backend.send :pagy_get_vars, @collection, vars
       assert_includes(merged.keys, :count)

--- a/test/test_helper/backend.rb
+++ b/test/test_helper/backend.rb
@@ -30,3 +30,11 @@ class TestCollection < Array
   end
 
 end
+
+class GroupedCollection < TestCollection
+
+  def count(*_)
+    @collection.map { |value| [value, value + 1] }.to_h
+  end
+
+end


### PR DESCRIPTION
This PR solves the `undefined method 'to_i' for Hash` exception for grouped AR collections (#50).