### PR TITLE
Added Turkish locales

### DIFF
--- a/lib/locales/pagy.yml
+++ b/lib/locales/pagy.yml
@@ -22,5 +22,27 @@ en:
     items:
       show: "Show"
       items: "items per page"
+tr:
+  pagy:
+    nav:
+      prev: "&lsaquo;&nbsp;Önceki"
+      next: "Sonraki&nbsp;&rsaquo;"
+      gap: "&hellip;"
+    info:
+      single_page:
+        zero: "Hiç %{item_name} bulunamadı."
+        one: "<b>1</b> %{item_name} gösteriliyor."
+        other: "Toplam <b>%{count}</b> %{item_name} gösteriliyor."
+      multiple_pages: "<b>%{count}</b> %{item_name} içerisinden <b>%{from}-%{to}</b> kadarı gösteriliyor."
+      item_name:
+        zero: "kayıt"
+        one: "kayıt"
+        other: "kayıt"
+    compact:
+      page: "Sayfa"
+      of: "/"
+    items:
+      show: "Göster"
+      items: "sayfa başı"
 
 # PR for other languages are very welcome. Thanks!


### PR DESCRIPTION
Added Turkish locales and tested against:

```ruby
<%== pagy_nav_compact(@pagy) %>
<%== pagy_nav(@pagy) %>
<%== pagy_info(@pagy) %>
```

Since Turkish is an agglutinative language (a way to make new words by adding suffixes to the end of words), it's not possible to make direct translations from English. For example it's not possible directly translate this to Turkish:

`Page 1 of 100.`

For that reason this has translated as `Sayfa 1 / 100.` which sounds and looks perfect in Turkish. Other strings are also tested with zero, one and more item combinations.