### PR TITLE
Typo in some extras usage

### DIFF
--- a/docs/extras/i18n.md
+++ b/docs/extras/i18n.md
@@ -13,7 +13,7 @@ See [extras](../extras.md) for general usage info.
 
 ```ruby
 # in the Pagy initializer
-require 'pagy/extra/i18n'
+require 'pagy/extras/i18n'
 ```
 
 ## Files

--- a/docs/extras/items.md
+++ b/docs/extras/items.md
@@ -12,7 +12,7 @@ See [extras](../extras.md) for general usage info.
 In the Pagy initializer:
 
 ```ruby
-require 'pagy/extra/items'
+require 'pagy/extras/items'
 
 Pagy::VARS[:items_param] = :custom_param       # default :items
 Pagy::VARS[:max_items]   = 100                 # default

--- a/docs/extras/responsive.md
+++ b/docs/extras/responsive.md
@@ -15,7 +15,7 @@ See [extras](../extras.md) for general usage info.
 
 ```ruby
 # in the Pagy initializer
-require 'pagy/extra/responsive'
+require 'pagy/extras/responsive'
 
 # set your default custom breakpoints (width/size pairs) globally (it can be overridden per Pagy instance)
 Pagy::VARS[:breakpoints] = {0 => [1,2,2,1], 450 => [3,4,4,3], 750 => [4,5,5,4]}


### PR DESCRIPTION
Fixed typo in i18n, items and responsive `require` examples.