### PR TITLE
Added Spanish locale

### DIFF
--- a/lib/locales/pagy.yml
+++ b/lib/locales/pagy.yml
@@ -23,6 +23,29 @@ en:
     items:
       show: "Show"
       items: "items per page"
+es:
+  pagy:
+    nav:
+      prev: "&lsaquo;&nbsp;Prev"
+      next: "Siguiente&nbsp;&rsaquo;"
+      gap: "&hellip;"
+      current: "Estás en la página"
+    info:
+      single_page:
+        zero: "Sin resultados"
+        one: "Mostrando 1 %{item_name}"
+        other: "Mostrando %{count} %{item_name}"
+      multiple_pages: "Mostrando %{item_name}s %{from}-%{to} de %{count} en total"
+      item_name:
+        zero: "items"
+        one: "item"
+        other: "items"
+    compact:
+      page: "Pagina"
+      of: "de"
+    items:
+      show: "Mostrar"
+      items: "items por página"
 tr:
   pagy:
     nav:

--- a/lib/locales/pagy.yml
+++ b/lib/locales/pagy.yml
@@ -37,15 +37,15 @@ es:
         other: "Mostrando %{count} %{item_name}"
       multiple_pages: "Mostrando %{item_name}s %{from}-%{to} de %{count} en total"
       item_name:
-        zero: "items"
-        one: "item"
-        other: "items"
+        zero: "ítems"
+        one: "ítem"
+        other: "ítems"
     compact:
       page: "Página"
       of: "de"
     items:
       show: "Mostrar"
-      items: "items por página"
+      items: "ítems por página"
 tr:
   pagy:
     nav:

--- a/lib/locales/pagy.yml
+++ b/lib/locales/pagy.yml
@@ -41,7 +41,7 @@ es:
         one: "item"
         other: "items"
     compact:
-      page: "Pagina"
+      page: "Página"
       of: "de"
     items:
       show: "Mostrar"


### PR DESCRIPTION
Added basic spanish translation to the locale pagy.yml.

Tested for pagy_nav, pagy_nav_compact and pagy_info.

For the label "info-single-page-zero" I decided to leave it as "Sin resultados" ("No results"), due to the fact that in spanish words have genre, so if the user is using the name of the resource instead of just "item", incoherent translations might happen ("found" needs to be translated as "encontrados" or "encontradas" depending on the resource name genre.).

On the other hand if the name of the resource is being used instead of "item", the pluralization is not being handled by this translation.