### PR TITLE
corrected chinese translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ Use the official extras, or write your own in just a few lines. Extras add speci
 
 Besides the classic pagination `nav`, Pagy offers a few ready to use alternatives like:
 
-- [compact nav](http://ddnexus.github.io/pagy/extras/navs#compact-navs): An alternative UI that combines the pagination feature with the navigation info in one compact element: ![pagy-compact](docs/assets/images/pagy-compact-w.png)
-- [responsive nav](http://ddnexus.github.io/pagy/extras/navs#responsive-navs): On resize, the number of page links adapts in real-time to the available window or container width: ![pagy-responsive](docs/assets/images/pagy-responsive-w.png)
+- [compact nav](http://ddnexus.github.io/pagy/extras/navs#compact-navs): An alternative UI that combines the pagination feature with the navigation info in one compact element:<br>![pagy-compact](docs/assets/images/pagy-compact-w.png)
+
+- [responsive nav](http://ddnexus.github.io/pagy/extras/navs#responsive-navs): On resize, the number of page links adapts in real-time to the available window or container width:<br>![pagy-responsive](docs/assets/images/pagy-responsive-w.png)
 
 ## Resources
 
@@ -121,6 +122,7 @@ Besides the classic pagination `nav`, Pagy offers a few ready to use alternative
 - [Pagination with Pagy](https://www.imaginarycloud.com/blog/paginating-ruby-on-rails-apps-with-pagy) by Tiago Franco
 - [Stateful Tabs with Pagy](https://www.imaginarycloud.com/blog/how-to-paginate-ruby-on-rails-apps-with-pagy) by Chris Seelus
 - [Quick guide for Pagy with Sinatra and Sequel](https://medium.com/@vfreefly/how-to-use-pagy-with-sequel-and-sinatra-157dfec1c417) by Victor Afanasev
+- [Integrating Pagy with Hanami](http://katafrakt.me/2018/06/01/integrating-pagy-with-hanami/) by Paweł Świątkowski
 - [Detailed Gems Comparison](https://ddnexus.github.io/pagination-comparison/gems.html) (charts and analisys)
 - [Benchmarks and Memory Profiles Source](http://github.com/ddnexus/pagination-comparison) (Rails app repository)
 

--- a/lib/locales/pagy.yml
+++ b/lib/locales/pagy.yml
@@ -1,27 +1,5 @@
 # Standard pagy dictionary
 
-cn:
-  pagy:
-    nav:
-      prev: "&lsaquo;&nbsp;上一页"
-      next: "下一页&nbsp;&rsaquo;"
-      gap: "&hellip;"
-    info:
-      single_page:
-        zero: " %{item_name} 未找到"
-        one: "显示 <b>1</b> %{item_name}"
-        other: "显示 <b>所有 %{count}</b> %{item_name}"
-      multiple_pages: "显示 %{item_name} <b>%{from}-%{to}</b> 共 <b>%{count}</b> 项"
-      item_name:
-        zero: "项"
-        one: "一个"
-        other: "多个"
-    compact:
-      page: "页"
-      of: "其中的"
-    items:
-      show: "显示"
-      items: "每页的条数"
 en:
   pagy:
     nav:
@@ -116,5 +94,27 @@ ru:
     items:
       show: "Показать"
       items: "записей на странице"
+zh-cn:
+  pagy:
+    nav:
+      prev: "&lsaquo;&nbsp;上一页"
+      next: "下一页&nbsp;&rsaquo;"
+      gap: "&hellip;"
+    info:
+      single_page:
+        zero: " %{item_name}未找到"
+        one: "显示 <b>1</b> 条%{item_name}"
+        other: "显示<b>所有 %{count}</b> 条%{item_name}"
+      multiple_pages: "共 <b>%{count}</b> 条%{item_name}，显示 <b>%{from}-%{to}</b>"
+      item_name:
+        zero: "项目"
+        one: ""
+        other: ""
+    compact:
+      page: "页面"
+      of: "/"
+    items:
+      show: "每页显示"
+      items: "条"
 
 # PR for other languages are very welcome. Thanks!


### PR DESCRIPTION
There are three things:
- the standard code for Chinese (language) is `zh` according to both ISO and IETF
- several mistranslation i.e. "items per page" was like "per-page item number"
- minimal tweaks to make sentences flow unobstructively