### PR TITLE
if has key "count" in pagy_get_vars, not run double sql query

### DIFF
--- a/lib/pagy/backend.rb
+++ b/lib/pagy/backend.rb
@@ -16,10 +16,17 @@ class Pagy
 
     # Sub-method called only by #pagy: here for easy customization of variables by overriding
     def pagy_get_vars(collection, vars)
-      count = collection.count(:all)                # work with AR collections: other ORMs may need to change this
-      count = count.count if count.is_a?(Hash)      # fix for the AR grouping count inconsistency (Hash instead of Integer)
+      count =
+        if vars.key?(:count)
+          vars[:count]
+        elsif collection.group_values.any?
+          collection.count(:all).count  # for the AR grouping count inconsistency (Hash instead of Integer)
+        else
+          collection.count(:all)        # work with AR collections: other ORMs may need to change this
+        end
+
       # Return the merged variables to initialize the Pagy object
-      { count: count, page: params[vars[:page_param]||VARS[:page_param]] }.merge!(vars)
+      { count: count, page: params[vars[:page_param] || VARS[:page_param]] }.merge!(vars)
     end
 
     # Sub-method called only by #pagy: here for easy customization of record-extraction by overriding

--- a/test/pagy/backend_test.rb
+++ b/test/pagy/backend_test.rb
@@ -63,6 +63,12 @@ describe Pagy::Backend do
       merged[:link_extra].must_equal 'X'
     end
 
+    it 'get count var' do
+      vars   = {count: 21}
+      merged = backend.send :pagy_get_vars, @collection, vars
+      merged[:count].must_equal 21
+    end
+
     it 'works with grouped collections' do
       @collection = TestGroupedCollection.new((1..1000).to_a)
       vars   = {page: 2, items: 10, link_extra: 'X'}

--- a/test/test_helper/backend.rb
+++ b/test/test_helper/backend.rb
@@ -29,6 +29,10 @@ class TestCollection < Array
     size
   end
 
+  def group_values
+    []
+  end
+
 end
 
 class TestGroupedCollection < TestCollection
@@ -37,4 +41,7 @@ class TestGroupedCollection < TestCollection
     @collection.map { |value| [value, value + 1] }.to_h
   end
 
+  def group_values
+    [:field]
+  end
 end


### PR DESCRIPTION
```ruby
users = User.social.order(id: :desc)

total_count =
  Rails.cache.fetch("users-count-#{users.query_cache_key}", expires_in: 30.minutes) do
    users.count(:all)
  end

@pagy, @users = pagy(Product.some_scope, count: total_count)
```