### PR TITLE
Cursor paginate

### DIFF
--- a/lib/pagy/cursor.rb
+++ b/lib/pagy/cursor.rb
@@ -1,0 +1,44 @@
+class Pagy
+
+  class Cursor < Pagy
+    attr_reader :before, :after, :arel_table, :primary_key, :order, :comparation, :position
+    attr_accessor :has_more
+    alias_method :has_more?, :has_more
+
+    def initialize(vars)
+      @vars = VARS.merge(vars.delete_if{|_,v| v.nil? || v == '' })
+      @items = vars[:items] || VARS[:items]
+      @before = vars[:before]
+      @after = vars[:after]
+      @arel_table = vars[:arel_table]
+      @primary_key = vars[:primary_key]
+      if @before.present? and @after.present?
+        raise(ArgumentError, 'before and after can not be both mentioned')
+      end
+
+      if vars[:backend] == 'uuid'
+
+        @comparation = 'lt' # arel table less than
+        @position = @before
+        @order = { :created_at => :desc , @primary_key => :desc }
+
+        if @after.present?
+          @comparation = 'gt' # arel table greater than
+          @position = @after
+          @order = { :created_at => :asc , @primary_key => :asc }
+        end
+      else
+
+        @comparation = 'lt'
+        @position = @before
+        @order = { @primary_key => :desc }
+
+        if @after.present?
+          @comparation = 'gt'
+          @position = @after
+          @order = { @primary_key => :asc }
+        end
+      end
+    end
+  end
+ end

--- a/lib/pagy/cursor.rb
+++ b/lib/pagy/cursor.rb
@@ -1,9 +1,10 @@
 class Pagy
 
   class Cursor < Pagy
-    attr_reader :before, :after, :arel_table, :primary_key, :order, :comparation, :position
-    attr_accessor :has_more
+    attr_reader :before, :after, :arel_table, :primary_key, :order, :comparation, :position, :prev_comparation
+    attr_accessor :has_more, :has_prev
     alias_method :has_more?, :has_more
+    alias_method :has_prev?, :has_more
 
     def initialize(vars)
       @vars = VARS.merge(vars.delete_if{|_,v| v.nil? || v == '' })
@@ -18,27 +19,29 @@ class Pagy
 
       if vars[:backend] == 'uuid'
 
-        @comparation = 'lt' # arel table less than
-        @position = @before
-        @order = { :created_at => :desc , @primary_key => :desc }
-
         if @after.present?
           @comparation = 'gt' # arel table greater than
           @position = @after
           @order = { :created_at => :asc , @primary_key => :asc }
+        else
+          @comparation = 'lt' # arel table less than
+          @position = @before
+          @order = { :created_at => :desc , @primary_key => :desc }
         end
-      else
 
-        @comparation = 'lt'
-        @position = @before
-        @order = { @primary_key => :desc }
+      else
 
         if @after.present?
           @comparation = 'gt'
           @position = @after
           @order = { @primary_key => :asc }
+        else      
+          @comparation = 'lt'
+          @position = @before
+          @order = { @primary_key => :desc }
         end
       end
+      
     end
   end
  end

--- a/lib/pagy/extras/cursor.rb
+++ b/lib/pagy/extras/cursor.rb
@@ -4,11 +4,11 @@ class Pagy
   module Backend ; private         # the whole module is private so no problem with including it in a controller
 
     # Return Pagy object and items
-    def pagy_cursor(collection, vars={}, options={})
+    def pagy_cursor(collection, vars={})
       raise('ActiveRecord is not defined') unless defined?(ActiveRecord)
       pagy = Pagy::Cursor.new(pagy_cursor_get_vars(collection, vars))
 
-      items =  pagy_cursor_get_items(collection, pagy, pagy.position)
+      items =  pagy_cursor_get_items(collection, pagy, pagy.comparation, pagy.position)
       pagy.has_more =  pagy_cursor_has_more?(items, pagy)
 
       return pagy, items
@@ -21,18 +21,17 @@ class Pagy
       vars
     end
 
-    def pagy_cursor_get_items(collection, pagy, position=nil)
+    def pagy_cursor_get_items(collection, pagy, comparation, position=nil)
       if position.present?
-        sql_comparation = pagy.arel_table[pagy.primary_key].send(pagy.comparation, position)
-        collection.where(sql_comparation).reorder(pagy.order).limit(pagy.items)
-      else
-        collection.reorder(pagy.order).limit(pagy.items)
+        sql_comparation = pagy.arel_table[pagy.primary_key].send(comparation, position)
+        collection = collection.where(sql_comparation)
       end
+      collection.reorder(pagy.order).limit(pagy.items)
     end
 
     def pagy_cursor_has_more?(collection, pagy)
       next_position = collection.last[pagy.primary_key]
-      pagy_cursor_get_items(collection, pagy, next_position).exists?
+      pagy_cursor_get_items(collection, pagy, pagy.comparation, next_position).exists?
     end
   end
 end

--- a/lib/pagy/extras/cursor.rb
+++ b/lib/pagy/extras/cursor.rb
@@ -1,39 +1,12 @@
+require 'pagy/cursor'
 class Pagy
-
-  attr_reader :before, :after, :arel_table, :primary_key, :order, :comparation, :position
-  attr_accessor :has_more
-  alias_method :has_more?, :has_more
-
-  def initialize(vars)
-    @vars = VARS.merge(vars.delete_if{|_,v| v.nil? || v == '' })
-    @items = vars[:items] || VARS[:items]
-    @before = vars[:before]
-    @after = vars[:after]
-    @arel_table = vars[:arel_table]
-    @primary_key = vars[:primary_key]
-
-    if @before.present? and @after.present?
-      raise(ArgumentError, 'before and after can not be both mentioned')
-    end
-    if @before.present?
-      @comparation = 'lt'
-      @position = @before
-      @order = { @primary_key => :desc }
-    end
-
-    if @after.present?
-      @comparation = 'gt'
-      @position = @after
-      @order = { @primary_key => :asc }
-    end
-  end
 
   module Backend ; private         # the whole module is private so no problem with including it in a controller
 
     # Return Pagy object and items
     def pagy_cursor(collection, vars={}, options={})
       raise('ActiveRecord is not defined') unless defined?(ActiveRecord)
-      pagy = Pagy.new(pagy_cursor_get_vars(collection, vars))
+      pagy = Pagy::Cursor.new(pagy_cursor_get_vars(collection, vars))
 
       items =  pagy_cursor_get_items(collection, pagy, pagy.position)
       pagy.has_more =  pagy_cursor_has_more?(items, pagy)
@@ -44,6 +17,7 @@ class Pagy
     def pagy_cursor_get_vars(collection, vars)
       vars[:arel_table] = collection.arel_table
       vars[:primary_key] = collection.primary_key
+      vars[:backend] = 'sequence'
       vars
     end
 

--- a/lib/pagy/extras/cursor.rb
+++ b/lib/pagy/extras/cursor.rb
@@ -33,7 +33,7 @@ class Pagy
     # Return Pagy object and items
     def pagy_cursor(collection, vars={}, options={})
       raise('ActiveRecord is not defined') unless defined?(ActiveRecord)
-      pagy = Pagy.new(pagy_array_get_vars(collection, vars))
+      pagy = Pagy.new(pagy_cursor_get_vars(collection, vars))
 
       items =  pagy_cursor_get_items(collection, pagy, pagy.position)
       pagy.has_more =  pagy_cursor_has_more?(items, pagy)
@@ -41,15 +41,19 @@ class Pagy
       return pagy, items
     end
 
-    def pagy_array_get_vars(collection, vars)
+    def pagy_cursor_get_vars(collection, vars)
       vars[:arel_table] = collection.arel_table
       vars[:primary_key] = collection.primary_key
       vars
     end
 
-    def pagy_cursor_get_items(collection, pagy, position)
-      sql_comparation = pagy.arel_table[pagy.primary_key].send(pagy.comparation, position)
-      collection.where(sql_comparation).reorder(pagy.order).limit(pagy.items)
+    def pagy_cursor_get_items(collection, pagy, position=nil)
+      if position.present?
+        sql_comparation = pagy.arel_table[pagy.primary_key].send(pagy.comparation, position)
+        collection.where(sql_comparation).reorder(pagy.order).limit(pagy.items)
+      else
+        collection.reorder(pagy.order).limit(pagy.items)
+      end
     end
 
     def pagy_cursor_has_more?(collection, pagy)

--- a/lib/pagy/extras/cursor.rb
+++ b/lib/pagy/extras/cursor.rb
@@ -1,0 +1,60 @@
+class Pagy
+
+  attr_reader :before, :after, :arel_table, :primary_key, :order, :comparation, :position
+  attr_accessor :has_more
+  alias_method :has_more?, :has_more
+
+  def initialize(vars)
+    @vars = VARS.merge(vars.delete_if{|_,v| v.nil? || v == '' })
+    @items = vars[:items] || VARS[:items]
+    @before = vars[:before]
+    @after = vars[:after]
+    @arel_table = vars[:arel_table]
+    @primary_key = vars[:primary_key]
+
+    if @before.present? and @after.present?
+      raise(ArgumentError, 'before and after can not be both mentioned')
+    end
+    if @before.present?
+      @comparation = 'lt'
+      @position = @before
+      @order = { @primary_key => :desc }
+    end
+
+    if @after.present?
+      @comparation = 'gt'
+      @position = @after
+      @order = { @primary_key => :asc }
+    end
+  end
+
+  module Backend ; private         # the whole module is private so no problem with including it in a controller
+
+    # Return Pagy object and items
+    def pagy_cursor(collection, vars={}, options={})
+      raise('ActiveRecord is not defined') unless defined?(ActiveRecord)
+      pagy = Pagy.new(pagy_array_get_vars(collection, vars))
+
+      items =  pagy_cursor_get_items(collection, pagy, pagy.position)
+      pagy.has_more =  pagy_cursor_has_more?(items, pagy)
+
+      return pagy, items
+    end
+
+    def pagy_array_get_vars(collection, vars)
+      vars[:arel_table] = collection.arel_table
+      vars[:primary_key] = collection.primary_key
+      vars
+    end
+
+    def pagy_cursor_get_items(collection, pagy, position)
+      sql_comparation = pagy.arel_table[pagy.primary_key].send(pagy.comparation, position)
+      collection.where(sql_comparation).reorder(pagy.order).limit(pagy.items)
+    end
+
+    def pagy_cursor_has_more?(collection, pagy)
+      next_position = collection.last[pagy.primary_key]
+      pagy_cursor_get_items(collection, pagy, next_position).exists?
+    end
+  end
+end

--- a/lib/pagy/extras/uuid_cursor.rb
+++ b/lib/pagy/extras/uuid_cursor.rb
@@ -28,10 +28,9 @@ class Pagy
         select_the_sample_created_at = arel_table[:created_at].eq(select_created_at).and(arel_table[pagy.primary_key].send(pagy.comparation, position))
         sql_comparation = arel_table[:created_at].send(pagy.comparation, select_created_at).or(select_the_sample_created_at)
 
-        collection.where(sql_comparation).reorder(pagy.order).limit(pagy.items)
-      else
-        collection.reorder(pagy.order).limit(pagy.items)
+        collection = collection.where(sql_comparation)
       end
+      collection.reorder(pagy.order).limit(pagy.items)
     end
 
     def pagy_uuid_cursor_has_more?(collection, pagy)

--- a/lib/pagy/extras/uuid_cursor.rb
+++ b/lib/pagy/extras/uuid_cursor.rb
@@ -1,6 +1,10 @@
+
+
 class Pagy
 
-  attr_reader :before, :after, :arel_table, :primary_key, :order
+  attr_reader :before, :after, :arel_table, :primary_key, :order, :comparation, :position
+  attr_accessor :has_more
+  alias_method :has_more?, :has_more
 
   def initialize(vars)
     @vars = VARS.merge(vars.delete_if{|_,v| v.nil? || v == '' })
@@ -14,43 +18,54 @@ class Pagy
       raise(ArgumentError, 'before and after can not be both mentioned')
     end
 
+    if @before.present?
+      @comparation = 'lt'
+      @position = @before
+      @order = { :created_at => :desc , @primary_key => :desc }
+    end
 
-    @order = { @primary_key => :desc } if @before.present?
-    @order = { @primary_key => :asc } if @after.present?
+    if @after.present?
+      @comparation = 'gt'
+      @position = @after
+      @order = { :created_at => :desc , @primary_key => :asc }
+    end
   end
 
   module Backend ; private         # the whole module is private so no problem with including it in a controller
 
     # Return Pagy object and items
-    def pagy_cursor(collection, vars={}, options={})
+    def pagy_uuid_cursor(collection, vars={}, options={})
       raise('ActiveRecord is not defined') unless defined?(ActiveRecord)
-      pagy = Pagy.new(pagy_array_get_vars(collection, vars))
-      return pagy, pagy_cursor_get_items(collection, pagy)
+      pagy = Pagy.new(pagy_uuid_cursor_get_vars(collection, vars))
+      items =  pagy_uuid_cursor_get_items(collection, pagy, pagy.position)
+      pagy.has_more =  pagy_uuid_cursor_has_more?(items, pagy)
+
+      return pagy, items
     end
 
-    def pagy_array_get_vars(collection, vars)
+    def pagy_uuid_cursor_get_vars(collection, vars)
       vars[:arel_table] = collection.arel_table
       vars[:primary_key] = collection.primary_key
       vars
     end
 
-    # Sub-method called only by #pagy: here for easy customization of record-extraction by overriding
-    def pagy_cursor_get_items(collection, pagy)
-      # This should work with ActiveRecord
-      records = collection
-      records = pagy_cursor_before(records, pagy)  if pagy.before.present?
-      records = pagy_cursor_after(records, pagy) if pagy.after.present?
-      records.limit(pagy.items)
+    def pagy_uuid_cursor_get_items(collection, pagy, position=nil)
+      if position.present?
+        arel_table = pagy.arel_table
+
+        select_created_at = arel_table.project(arel_table[:created_at]).where(arel_table[pagy.primary_key].eq(position))
+        select_the_sample_created_at = arel_table[:created_at].eq(select_created_at).and(arel_table[pagy.primary_key].gt(position))
+        sql_comparation = arel_table[:created_at].gt(select_created_at).or(select_the_sample_created_at)
+
+        collection.where(sql_comparation).reorder(pagy.order).limit(pagy.items)
+      else
+        collection.reorder(pagy.order).limit(pagy.items)
+      end
     end
 
-    def pagy_cursor_before(collection, pagy)
-      # This should work with ActiveRecord
-      collection.where(pagy.arel_table[pagy.primary_key].lt(pagy.before)).reorder(pagy.order)
-    end
-
-    def pagy_cursor_after(collection, pagy)
-      # This should work with ActiveRecord
-      collection.where(pagy.arel_table[pagy.primary_key].gt(pagy.after)).reorder(pagy.order)
+    def pagy_uuid_cursor_has_more?(collection, pagy)
+      next_position = collection.last[pagy.primary_key]
+      pagy_uuid_cursor_get_items(collection, pagy, next_position).exists?
     end
   end
 end

--- a/lib/pagy/extras/uuid_cursor.rb
+++ b/lib/pagy/extras/uuid_cursor.rb
@@ -1,0 +1,56 @@
+class Pagy
+
+  attr_reader :before, :after, :arel_table, :primary_key, :order
+
+  def initialize(vars)
+    @vars = VARS.merge(vars.delete_if{|_,v| v.nil? || v == '' })
+    @items = vars[:items] || VARS[:items]
+    @before = vars[:before]
+    @after = vars[:after]
+    @arel_table = vars[:arel_table]
+    @primary_key = vars[:primary_key]
+
+    if @before.present? and @after.present?
+      raise(ArgumentError, 'before and after can not be both mentioned')
+    end
+
+
+    @order = { @primary_key => :desc } if @before.present?
+    @order = { @primary_key => :asc } if @after.present?
+  end
+
+  module Backend ; private         # the whole module is private so no problem with including it in a controller
+
+    # Return Pagy object and items
+    def pagy_cursor(collection, vars={}, options={})
+      raise('ActiveRecord is not defined') unless defined?(ActiveRecord)
+      pagy = Pagy.new(pagy_array_get_vars(collection, vars))
+      return pagy, pagy_cursor_get_items(collection, pagy)
+    end
+
+    def pagy_array_get_vars(collection, vars)
+      vars[:arel_table] = collection.arel_table
+      vars[:primary_key] = collection.primary_key
+      vars
+    end
+
+    # Sub-method called only by #pagy: here for easy customization of record-extraction by overriding
+    def pagy_cursor_get_items(collection, pagy)
+      # This should work with ActiveRecord
+      records = collection
+      records = pagy_cursor_before(records, pagy)  if pagy.before.present?
+      records = pagy_cursor_after(records, pagy) if pagy.after.present?
+      records.limit(pagy.items)
+    end
+
+    def pagy_cursor_before(collection, pagy)
+      # This should work with ActiveRecord
+      collection.where(pagy.arel_table[pagy.primary_key].lt(pagy.before)).reorder(pagy.order)
+    end
+
+    def pagy_cursor_after(collection, pagy)
+      # This should work with ActiveRecord
+      collection.where(pagy.arel_table[pagy.primary_key].gt(pagy.after)).reorder(pagy.order)
+    end
+  end
+end

--- a/lib/pagy/extras/uuid_cursor.rb
+++ b/lib/pagy/extras/uuid_cursor.rb
@@ -4,7 +4,7 @@ class Pagy
   module Backend ; private         # the whole module is private so no problem with including it in a controller
 
     # Return Pagy object and items
-    def pagy_uuid_cursor(collection, vars={}, options={})
+    def pagy_uuid_cursor(collection, vars={})
       raise('ActiveRecord is not defined') unless defined?(ActiveRecord)
       pagy = Pagy::Cursor.new(pagy_uuid_cursor_get_vars(collection, vars))
       items =  pagy_uuid_cursor_get_items(collection, pagy, pagy.position)

--- a/lib/pagy/extras/uuid_cursor.rb
+++ b/lib/pagy/extras/uuid_cursor.rb
@@ -1,42 +1,12 @@
-
-
+require 'pagy/cursor'
 class Pagy
-
-  attr_reader :before, :after, :arel_table, :primary_key, :order, :comparation, :position
-  attr_accessor :has_more
-  alias_method :has_more?, :has_more
-
-  def initialize(vars)
-    @vars = VARS.merge(vars.delete_if{|_,v| v.nil? || v == '' })
-    @items = vars[:items] || VARS[:items]
-    @before = vars[:before]
-    @after = vars[:after]
-    @arel_table = vars[:arel_table]
-    @primary_key = vars[:primary_key]
-
-    if @before.present? and @after.present?
-      raise(ArgumentError, 'before and after can not be both mentioned')
-    end
-
-    if @before.present?
-      @comparation = 'lt'
-      @position = @before
-      @order = { :created_at => :desc , @primary_key => :desc }
-    end
-
-    if @after.present?
-      @comparation = 'gt'
-      @position = @after
-      @order = { :created_at => :desc , @primary_key => :asc }
-    end
-  end
 
   module Backend ; private         # the whole module is private so no problem with including it in a controller
 
     # Return Pagy object and items
     def pagy_uuid_cursor(collection, vars={}, options={})
       raise('ActiveRecord is not defined') unless defined?(ActiveRecord)
-      pagy = Pagy.new(pagy_uuid_cursor_get_vars(collection, vars))
+      pagy = Pagy::Cursor.new(pagy_uuid_cursor_get_vars(collection, vars))
       items =  pagy_uuid_cursor_get_items(collection, pagy, pagy.position)
       pagy.has_more =  pagy_uuid_cursor_has_more?(items, pagy)
 
@@ -46,6 +16,7 @@ class Pagy
     def pagy_uuid_cursor_get_vars(collection, vars)
       vars[:arel_table] = collection.arel_table
       vars[:primary_key] = collection.primary_key
+      vars[:backend] = 'uuid'
       vars
     end
 
@@ -54,8 +25,8 @@ class Pagy
         arel_table = pagy.arel_table
 
         select_created_at = arel_table.project(arel_table[:created_at]).where(arel_table[pagy.primary_key].eq(position))
-        select_the_sample_created_at = arel_table[:created_at].eq(select_created_at).and(arel_table[pagy.primary_key].gt(position))
-        sql_comparation = arel_table[:created_at].gt(select_created_at).or(select_the_sample_created_at)
+        select_the_sample_created_at = arel_table[:created_at].eq(select_created_at).and(arel_table[pagy.primary_key].send(pagy.comparation, position))
+        sql_comparation = arel_table[:created_at].send(pagy.comparation, select_created_at).or(select_the_sample_created_at)
 
         collection.where(sql_comparation).reorder(pagy.order).limit(pagy.items)
       else


### PR DESCRIPTION
Add cursor paginate that support only ActiveRecord

What is cursor paginate? [Offset and Cursor](https://dev.to/jackmarchant/offset-and-cursor-pagination-explained-b89)

****Current Support***: cursor_paginate for ['sequence', 'uuid'], has_more?

***Test***: Coming (need to integrate with ActiveRecord) (need help) 
***Doc***: Coming
***Custom Order***: After this is a good idea
***Note***: Open for any suggestion
