### PR TITLE
Use "Link" instead of "Links" for header extra

### DIFF
--- a/docs/extras/headers.md
+++ b/docs/extras/headers.md
@@ -51,14 +51,14 @@ This extra is composed of 1 small file:
 
 ## Headers
 
-This extra adds the standard/legacy headers used by various API-pagination gems with `Links`, `Per-Page` and `Total` headers, so it is a convenient replacement for legacy apps that use external gems.
+This extra adds the standard/legacy headers used by various API-pagination gems with `Link`, `Per-Page` and `Total` headers, so it is a convenient replacement for legacy apps that use external gems.
 
 For new apps, and for consistency with the Pagy naming, you may want to use the `Items` (instead of Per-Page) and `Count` (instead of Total) aliases.
 
 Example of HTTP headers produced:
 
 ```
-Links <https://example.com:8080/foo?page=1>; rel="first", <https://example.com:8080/foo?page=2>; rel="prev", <https://example.com:8080/foo?page=4>; rel="next", <https://example.com:8080/foo?page=50>; rel="last"
+Link <https://example.com:8080/foo?page=1>; rel="first", <https://example.com:8080/foo?page=2>; rel="prev", <https://example.com:8080/foo?page=4>; rel="next", <https://example.com:8080/foo?page=50>; rel="last"
 Items 20 
 Per-Page 20 
 Count 1000 
@@ -72,7 +72,7 @@ If your requirements allow to save one count-query per rendering by using the `p
 Example of HTTP headers produced from a `Pagy::Countless` object:
 
 ```
-Links <https://example.com:8080/foo?page=1>; rel="first", <https://example.com:8080/foo?page=2>; rel="prev", <https://example.com:8080/foo?page=4>; rel="next"
+Link <https://example.com:8080/foo?page=1>; rel="first", <https://example.com:8080/foo?page=2>; rel="prev", <https://example.com:8080/foo?page=4>; rel="next"
 Items 20 
 Per-Page 20 
 ```

--- a/lib/pagy/extras/headers.rb
+++ b/lib/pagy/extras/headers.rb
@@ -14,7 +14,7 @@ class Pagy
 
     def pagy_headers(pagy)
       hash = pagy_headers_hash(pagy)
-      { 'Links'    => hash[:links].map{|rel, link| %(<#{link}>; rel="#{rel}")}.join(', ') }.tap do |h|
+      { 'Link'    => hash[:links].map{|rel, link| %(<#{link}>; rel="#{rel}")}.join(', ') }.tap do |h|
         h['Items'] = h['Per-Page'] = hash[:items]
         h['Count'] = h['Total']    = hash[:count] if hash.key?(:count)
       end

--- a/test/pagy/extras/headers_test.rb
+++ b/test/pagy/extras/headers_test.rb
@@ -18,22 +18,22 @@ describe Pagy::Backend do
 
     it 'returns the full headers hash' do
       pagy, _records = @controller.send(:pagy, @collection)
-      @controller.send(:pagy_headers, pagy).must_equal({"Links"=>"<https://example.com:8080/foo?page=1>; rel=\"first\", <https://example.com:8080/foo?page=2>; rel=\"prev\", <https://example.com:8080/foo?page=4>; rel=\"next\", <https://example.com:8080/foo?page=50>; rel=\"last\"", "Items"=>20, "Per-Page"=>20, "Count"=>1000, "Total"=>1000})
+      @controller.send(:pagy_headers, pagy).must_equal({"Link"=>"<https://example.com:8080/foo?page=1>; rel=\"first\", <https://example.com:8080/foo?page=2>; rel=\"prev\", <https://example.com:8080/foo?page=4>; rel=\"next\", <https://example.com:8080/foo?page=50>; rel=\"last\"", "Items"=>20, "Per-Page"=>20, "Count"=>1000, "Total"=>1000})
     end
 
     it 'returns the countless headers hash' do
       pagy, _records = @controller.send(:pagy_countless, @collection)
-      @controller.send(:pagy_headers, pagy).must_equal({"Links"=>"<https://example.com:8080/foo?page=1>; rel=\"first\", <https://example.com:8080/foo?page=2>; rel=\"prev\", <https://example.com:8080/foo?page=4>; rel=\"next\"", "Items"=>20, "Per-Page"=>20})
+      @controller.send(:pagy_headers, pagy).must_equal({"Link"=>"<https://example.com:8080/foo?page=1>; rel=\"first\", <https://example.com:8080/foo?page=2>; rel=\"prev\", <https://example.com:8080/foo?page=4>; rel=\"next\"", "Items"=>20, "Per-Page"=>20})
     end
 
     it 'omit prev on first page' do
       pagy, _records = @controller.send(:pagy, @collection, page: 1)
-      @controller.send(:pagy_headers, pagy).must_equal({"Links"=>"<https://example.com:8080/foo?page=1>; rel=\"first\", <https://example.com:8080/foo?page=2>; rel=\"next\", <https://example.com:8080/foo?page=50>; rel=\"last\"", "Items"=>20, "Per-Page"=>20, "Count"=>1000, "Total"=>1000})
+      @controller.send(:pagy_headers, pagy).must_equal({"Link"=>"<https://example.com:8080/foo?page=1>; rel=\"first\", <https://example.com:8080/foo?page=2>; rel=\"next\", <https://example.com:8080/foo?page=50>; rel=\"last\"", "Items"=>20, "Per-Page"=>20, "Count"=>1000, "Total"=>1000})
     end
 
     it 'omit next on last page' do
       pagy, _records = @controller.send(:pagy, @collection, page: 50)
-      @controller.send(:pagy_headers, pagy).must_equal({"Links"=>"<https://example.com:8080/foo?page=1>; rel=\"first\", <https://example.com:8080/foo?page=49>; rel=\"prev\", <https://example.com:8080/foo?page=50>; rel=\"last\"", "Items"=>20, "Per-Page"=>20, "Count"=>1000, "Total"=>1000})
+      @controller.send(:pagy_headers, pagy).must_equal({"Link"=>"<https://example.com:8080/foo?page=1>; rel=\"first\", <https://example.com:8080/foo?page=49>; rel=\"prev\", <https://example.com:8080/foo?page=50>; rel=\"last\"", "Items"=>20, "Per-Page"=>20, "Count"=>1000, "Total"=>1000})
     end
 
   end
@@ -48,7 +48,7 @@ describe Pagy::Backend do
     it 'returns the full headers hash' do
       pagy, _records = @controller.send(:pagy, @collection)
       @controller.send(:pagy_headers_merge, pagy)
-      @controller.send(:response).headers.must_equal({"Links"=>"<https://example.com:8080/foo?page=1>; rel=\"first\", <https://example.com:8080/foo?page=2>; rel=\"prev\", <https://example.com:8080/foo?page=4>; rel=\"next\", <https://example.com:8080/foo?page=50>; rel=\"last\"", "Items"=>20, "Per-Page"=>20, "Count"=>1000, "Total"=>1000})
+      @controller.send(:response).headers.must_equal({"Link"=>"<https://example.com:8080/foo?page=1>; rel=\"first\", <https://example.com:8080/foo?page=2>; rel=\"prev\", <https://example.com:8080/foo?page=4>; rel=\"next\", <https://example.com:8080/foo?page=50>; rel=\"last\"", "Items"=>20, "Per-Page"=>20, "Count"=>1000, "Total"=>1000})
     end
 
   end


### PR DESCRIPTION
Just looked at the `README` for the headers feature and it really looked simple enough, so I couldn’t resist testing it.

Purging the api-pagination gem and replacing the API stuff was really straight forward, simple and quick.

At first glance with Postman everything looked ok, so I started up an App in iOS Simulator that consumes the API and paging didn’t work. 
So looking closer at the links Pagy injects, I saw that you use 
```
    Links →<…
```
instead of
```
    Link →<…
```

I think it would be hard to justify changing Apps that consume the API(s) the headers extra could be used for and [RFC 8288](https://tools.ietf.org/html/rfc8288) (page 14) also uses Link like api-pagination, so you might reconsider this.