### PR TITLE
update how-to documentation

### DIFF
--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -10,7 +10,7 @@ This page contains the practical tips and examples to get the job done with Pagy
 If you use Bundler, add the gem in the Gemfile:
 
 ```ruby
-gem 'pagy'
+gem 'pagy', '~> 3.4.1' # the latest version to-date
 ```
 
 or if you don't, just install and require the Pagy gem:


### PR DESCRIPTION
**Why this change?**

Because people may cut and paste (as I did) without remembering to limit the gem to a particular version - to avoid the situations where there are breaking api changes which may catch people unawares. So I thought it best to add a version limitation.

I hope this helps.