### PR TITLE
Adding elasticsearch7 support

### DIFF
--- a/lib/pagy/extras/elasticsearch_rails.rb
+++ b/lib/pagy/extras/elasticsearch_rails.rb
@@ -13,7 +13,8 @@ class Pagy
   def self.new_from_elasticsearch_rails(response, vars={})
     vars[:items] = response.search.options[:size] || 10
     vars[:page]  = (response.search.options[:from] || 0) / vars[:items] + 1
-    vars[:count] = response.raw_response['hits']['total']
+    total = response.raw_response['hits']['total']
+    vars[:count] = total.is_a?(Hash) ? total['value'] : total
     new(vars)
   end
 
@@ -27,7 +28,8 @@ class Pagy
       search_args[-1][:size] = vars[:items]
       search_args[-1][:from] = vars[:items] * (vars[:page] - 1)
       response               = model.search(*search_args)
-      vars[:count]           = response.raw_response['hits']['total']
+      total                  = response.raw_response['hits']['total']
+      vars[:count]           = total.is_a?(Hash) ? total['value'] : total
       pagy = Pagy.new(vars)
       # with :last_page overflow we need to re-run the method in order to get the hits
       if defined?(OVERFLOW) && pagy.overflow? && pagy.vars[:overflow] == :last_page

--- a/lib/pagy/extras/elasticsearch_rails.rb
+++ b/lib/pagy/extras/elasticsearch_rails.rb
@@ -13,7 +13,7 @@ class Pagy
   def self.new_from_elasticsearch_rails(response, vars={})
     vars[:items] = response.search.options[:size] || 10
     vars[:page]  = (response.search.options[:from] || 0) / vars[:items] + 1
-    total = response.raw_response['hits']['total']
+    total        = response.raw_response['hits']['total']
     vars[:count] = total.is_a?(Hash) ? total['value'] : total
     new(vars)
   end

--- a/test/mock_helpers/elasticsearch_rails.rb
+++ b/test/mock_helpers/elasticsearch_rails.rb
@@ -44,4 +44,20 @@ module MockElasticsearchRails
     extend Pagy::Search
   end
 
+  class ResponseES7 < Response
+
+    def initialize(query, options={})
+      super(query, options)
+      @raw_response = {'hits' => {'hits' => @search.results, 'total' => {'value' => RESULTS[query].size}}}
+    end
+
+  end
+
+  class ModelES7 < Model
+
+    def self.search(*args)
+      ResponseES7.new(*args)
+    end
+
+  end
 end

--- a/test/pagy/extras/elasticsearch_rails_test.rb
+++ b/test/pagy/extras/elasticsearch_rails_test.rb
@@ -86,6 +86,57 @@ describe Pagy::Backend do
 
   end
 
+  describe "#pagy_elasticsearch7_rails" do
+
+    before do
+      @collection = MockCollection.new
+    end
+
+    it 'paginates response with defaults' do
+      pagy, response = controller.send(:pagy_elasticsearch_rails, MockElasticsearchRails::ModelES7.pagy_search('a'))
+      records = response.records
+      pagy.must_be_instance_of Pagy
+      pagy.count.must_equal 1000
+      pagy.items.must_equal Pagy::VARS[:items]
+      pagy.page.must_equal controller.params[:page]
+      records.count.must_equal Pagy::VARS[:items]
+      records.must_equal ["R-a-41", "R-a-42", "R-a-43", "R-a-44", "R-a-45", "R-a-46", "R-a-47", "R-a-48", "R-a-49", "R-a-50", "R-a-51", "R-a-52", "R-a-53", "R-a-54", "R-a-55", "R-a-56", "R-a-57", "R-a-58", "R-a-59", "R-a-60"]
+    end
+
+    it 'paginates records with defaults' do
+      pagy, records = controller.send(:pagy_elasticsearch_rails, MockElasticsearchRails::ModelES7.pagy_search('a').records)
+      pagy.must_be_instance_of Pagy
+      pagy.count.must_equal 1000
+      pagy.items.must_equal Pagy::VARS[:items]
+      pagy.page.must_equal controller.params[:page]
+      records.count.must_equal Pagy::VARS[:items]
+      records.must_equal ["R-a-41", "R-a-42", "R-a-43", "R-a-44", "R-a-45", "R-a-46", "R-a-47", "R-a-48", "R-a-49", "R-a-50", "R-a-51", "R-a-52", "R-a-53", "R-a-54", "R-a-55", "R-a-56", "R-a-57", "R-a-58", "R-a-59", "R-a-60"]
+    end
+
+    it 'paginates with vars' do
+      pagy, records = controller.send(:pagy_elasticsearch_rails, MockElasticsearchRails::ModelES7.pagy_search('b').records, page: 2, items: 10, link_extra: 'X')
+      pagy.must_be_instance_of Pagy
+      pagy.count.must_equal 1000
+      pagy.items.must_equal 10
+      pagy.page.must_equal 2
+      pagy.vars[:link_extra].must_equal 'X'
+      records.count.must_equal 10
+      records.must_equal ["R-b-11", "R-b-12", "R-b-13", "R-b-14", "R-b-15", "R-b-16", "R-b-17", "R-b-18", "R-b-19", "R-b-20"]
+    end
+
+    it 'paginates with overflow' do
+      pagy, records = controller.send(:pagy_elasticsearch_rails, MockElasticsearchRails::Model.pagy_search('b').records, page: 200, items: 10, link_extra: 'X', overflow: :last_page)
+      pagy.must_be_instance_of Pagy
+      pagy.count.must_equal 1000
+      pagy.items.must_equal 10
+      pagy.page.must_equal 100
+      pagy.vars[:link_extra].must_equal 'X'
+      records.count.must_equal 10
+      records.must_equal ["R-b-991", "R-b-992", "R-b-993", "R-b-994", "R-b-995", "R-b-996", "R-b-997", "R-b-998", "R-b-999", "R-b-1000"]
+    end
+
+  end
+
   describe '#pagy_elasticsearch_rails_get_vars' do
 
     it 'gets defaults' do


### PR DESCRIPTION
Elasticsearch 7 changed the way it returns the [`total` attribute in the response](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/search-request-body.html#request-body-search-track-total-hits). It is now a hash instead of an integer. This PR adds support for the hash.

Fixes #184 