### PR TITLE
remove order from scope

### DIFF
--- a/lib/pagy/backend.rb
+++ b/lib/pagy/backend.rb
@@ -18,7 +18,7 @@ class Pagy
 
     # Sub-method called only by #pagy: here for easy customization of variables by overriding
     def pagy_get_vars(collection, vars)
-      vars[:count] ||= (c = collection.count(:all)).is_a?(Hash) ? c.size : c
+      vars[:count] ||= (c = collection.unscope(:order).count(:all)).is_a?(Hash) ? c.size : c
       vars[:page]  ||= params[ vars[:page_param] || VARS[:page_param] ]
       vars
     end

--- a/test/mock_helpers/collection.rb
+++ b/test/mock_helpers/collection.rb
@@ -18,6 +18,10 @@ class MockCollection < Array
     size
   end
 
+  def unscope(*)
+    self
+  end
+
   class Grouped < MockCollection
 
     def count(*)


### PR DESCRIPTION
When the select statement has a alias for a table/formula, and we order by it, then rails `count(:all)` will still use the order. In my case this makes it fail. Removing the order makes it work.