### PR TITLE
Rename Swedish locale to sv.yml

### DIFF
--- a/lib/locales/sv-SE.yml
+++ b/lib/locales/sv-SE.yml
@@ -1,0 +1,23 @@
+# :one_two_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/locales/utils/p11n.rb)
+
+sv-SE:
+  pagy:
+
+    item_name:
+      one: "resultat"
+      two: "resultat"
+      other: "resultat"
+
+    nav:
+      prev: "&lsaquo;&nbsp;Föregående"
+      next: "Nästa&nbsp;&rsaquo;"
+      gap: "&hellip;"
+
+    info:
+      no_items: "Inga %{item_name} hittade"
+      single_page: "Visar <b>%{count}</b> %{item_name}"
+      multiple_pages: "Visar %{item_name} <b>%{from}-%{to}</b> av <b>%{count}</b> totalt"
+
+    combo_nav_js: "Sida %{page_input} av %{pages}"
+
+    items_selector_js: "Visa %{items_input} %{item_name} per sida"

--- a/lib/locales/sv.yml
+++ b/lib/locales/sv.yml
@@ -1,6 +1,6 @@
 # :one_two_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/locales/utils/p11n.rb)
 
-se:
+sv:
   pagy:
 
     item_name:


### PR DESCRIPTION
- The Swedish locale is referred to as sv in the I18n-gem:
  https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/sv.yml
- It can also be referred to as sv_SE.