### PR TITLE
add items_per_page set to original value of items

### DIFF
--- a/lib/pagy.rb
+++ b/lib/pagy.rb
@@ -12,7 +12,7 @@ class Pagy ; VERSION = '3.7.3'
   # default vars
   VARS = { page:1, items:20, outset:0, size:[1,4,4,1], page_param: :page, params:{}, anchor:'', link_extra:'', i18n_key:'pagy.item_name', cycle:false }
 
-  attr_reader :count, :page, :items, :vars, :pages, :last, :offset, :from, :to, :prev, :next
+  attr_reader :count, :page, :items, :vars, :pages, :last, :offset, :from, :to, :prev, :next, :items_per_page
 
   # Merge and validate the options, do some simple arithmetic and set the instance variables
   def initialize(vars)
@@ -24,6 +24,7 @@ class Pagy ; VERSION = '3.7.3'
     @pages = @last = [(@count.to_f / @items).ceil, 1].max                      # cardinal and ordinal meanings
     @page <= @last or raise(OverflowError.new(self), "expected :page in 1..#{@last}; got #{@page.inspect}")
     @offset = @items * (@page - 1) + @outset                                   # pagination offset + outset (initial offset)
+    @items_per_page = @items                                                   # keep original items per page
     @items  = @count - ((@pages-1) * @items) if @page == @last && @count > 0   # adjust items for last non-empty page
     @from   = @count == 0 ? 0 : @offset+1 - @outset                            # page begins from item
     @to     = @count == 0 ? 0 : @offset + @items - @outset                     # page ends to item


### PR DESCRIPTION
I ran into an astonishing issue. I was passing the Pagy instance to my custom pagination component and using its `items` attribute to set the selected option of a dropdown to select items per page. I happened to filter my data so that there were only 5 results, and the select changed to 5. I then discovered that `items` gets adjusted to the number of items when on the last page (when there were only 5 results, there was only one page, so it was on the last page).

As a workaround, I've had to explicitly pass the `items` value separately to my pagination component. However it would be nice if Pagy kept the original value of `items` somewhere so that it can be used for purposes similar to my own.

This PR is my suggestion as to how this could be achieved without any breaking changes.