### PR TITLE
Danish translation for Pagy

### DIFF
--- a/lib/locales/da.yml
+++ b/lib/locales/da.yml
@@ -1,0 +1,22 @@
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/locales/utils/p11n.rb)
+
+da:
+  pagy:
+
+    item_name:
+      one: "resultat"
+      other: "resultater"
+
+    nav:
+      prev: "&lsaquo;&nbsp;Forrige"
+      next: "Næste&nbsp;&rsaquo;"
+      gap: "&hellip;"
+
+    info:
+      no_items: "Ingen %{item_name} fundet"
+      single_page: "Viser <b>%{count}</b> %{item_name}"
+      multiple_pages: "Viser %{item_name} <b>%{from}-%{to}</b> til <b>%{count}</b> totalt"
+
+    combo_nav_js: "Side %{page_input} of %{pages}"
+
+    items_selector_js: "Antal %{items_input} %{item_name} per side"


### PR DESCRIPTION
Hi there! 

Here is the Danish translation. I decided to follow as closely as possible the Swedish and Norwegian translations (but actually copied the EN file for this translation).

I hope you can use it 👍 

### Check list for a new dictionary file:

- [x] Find the pluralization rule for your language
    - find the locale file you need in the [list of pluralizations](https://github.com/svenfuchs/rails-i18n/tree/master/rails/pluralization) and check the pluralization rule in it. For example for `en.rb` it is`::RailsI18n::Pluralization::OneOther.with_locale(:en)`. Note the rule part i.e. `OneOther`. In pagy that translates to the symbol `:one_other`.

- [x] add/edit the first line comment in the language rule in your dictionary file (e.g. `# :one_other pluralization ...`

- [x] The mandatory pluralized entry in the dictionary file is the `item_name`. Please, provide all the plurals needed by your language. E.g. if your language uses the `:east_slavic` you should provide the plurals for `one`, `few`, `many` and `other`, if it uses `:one_other`, you should provide `one` and `other` plurals. If it uses `:other` you should only provide a single value. Look into other dictionary files to get some example. Ask if in doubt.

- [x] The other entries in the dictionary file don't need any plural variant in most languages since the pluralization of the `item_name` in the sentence is enough. However, in some language, the whole sentence needs to be written in a different way for different plurals. In that case you should add the different plurals for the sentence and they will get triggered by the `count`.

### Useful Links

* [Pagy I18n Documentation](https://ddnexus.github.io/pagy/api/frontend#i18n)
* [I18n Extra](https://ddnexus.github.io/pagy/extras/i18n)
