### PR TITLE
Fixes boundary character escaping in regex in js trim function

### DIFF
--- a/lib/javascripts/pagy.js
+++ b/lib/javascripts/pagy.js
@@ -101,6 +101,6 @@ Pagy.addInputEventListeners = function(input, handler){
                               };
 
 Pagy.trim = function(html, param){
-              var re = new RegExp('[?&]' + param + '=1\b(?!&)|\b' + param + '=1&');
+              var re = new RegExp('[?&]' + param + '=1\\b(?!&)|\\b' + param + '=1&');
               return html.replace(re, '');
             };


### PR DESCRIPTION
Fixes #238 
adding additional backslash https://www.w3schools.com/Jsref/jsref_regexp_begin.asp fixes it

is it possible to add js tests?