### PR TITLE
fix for deprecation warnings in ruby 2.7.x

### DIFF
--- a/lib/pagy/extras/i18n.rb
+++ b/lib/pagy/extras/i18n.rb
@@ -11,7 +11,7 @@ class Pagy
     Pagy::I18n.clear.instance_eval { undef :load; undef :t } # unload the pagy default constant for efficiency
 
     alias_method :pagy_without_i18n, :pagy_t
-    def pagy_t_with_i18n(*args) ::I18n.t(*args) end
+    def pagy_t_with_i18n(**args) ::I18n.t(*args) end
     alias_method :pagy_t, :pagy_t_with_i18n
 
   end

--- a/lib/pagy/extras/shared.rb
+++ b/lib/pagy/extras/shared.rb
@@ -27,13 +27,13 @@ class Pagy
 
     if defined?(Oj)
       # it returns a script tag with the JSON-serialized args generated with the faster oj gem
-      def pagy_json_tag(*args)
+      def pagy_json_tag(**args)
         %(<script type="application/json" class="pagy-json">#{Oj.dump(args, mode: :strict)}</script>)
       end
     else
       require 'json'
       # it returns a script tag with the JSON-serialized args generated with the slower to_json
-      def pagy_json_tag(*args)
+      def pagy_json_tag(**args)
         %(<script type="application/json" class="pagy-json">#{args.to_json}</script>)
       end
     end


### PR DESCRIPTION
This pull request fixes the warnings for Ruby 2.7.x.