### PR TITLE
Use proper attributes for "previous" links

### DIFF
--- a/lib/pagy/extras/support.rb
+++ b/lib/pagy/extras/support.rb
@@ -15,7 +15,7 @@ class Pagy
     end
 
     def pagy_prev_link(pagy, text = pagy_t('pagy.nav.prev'), link_extra = '')
-      pagy.prev ? %(<span class="page prev"><a href="#{pagy_prev_url(pagy)}" rel="next" aria-label="next" #{pagy.vars[:link_extra]} #{link_extra}>#{text}</a></span>)
+      pagy.prev ? %(<span class="page prev"><a href="#{pagy_prev_url(pagy)}" rel="prev" aria-label="previous" #{pagy.vars[:link_extra]} #{link_extra}>#{text}</a></span>)
                 : %(<span class="page prev disabled">#{text}</span>)
     end
 

--- a/test/pagy/extras/support_test.rb
+++ b/test/pagy/extras/support_test.rb
@@ -87,22 +87,22 @@ describe Pagy::Frontend do
     it 'renders the prev link for page 3' do
       pagy = Pagy.new count: 1000, page: 3
       pagy_countless = Pagy::Countless.new(page: 3).finalize(21)
-      _(view.pagy_prev_link(pagy)).must_equal "<span class=\"page prev\"><a href=\"/foo?page=2\" rel=\"next\" aria-label=\"next\"  >&lsaquo;&nbsp;Prev</a></span>"
-      _(view.pagy_prev_link(pagy_countless)).must_equal "<span class=\"page prev\"><a href=\"/foo?page=2\" rel=\"next\" aria-label=\"next\"  >&lsaquo;&nbsp;Prev</a></span>"
+      _(view.pagy_prev_link(pagy)).must_equal "<span class=\"page prev\"><a href=\"/foo?page=2\" rel=\"prev\" aria-label=\"previous\"  >&lsaquo;&nbsp;Prev</a></span>"
+      _(view.pagy_prev_link(pagy_countless)).must_equal "<span class=\"page prev\"><a href=\"/foo?page=2\" rel=\"prev\" aria-label=\"previous\"  >&lsaquo;&nbsp;Prev</a></span>"
     end
 
     it 'renders the prev link for page 6' do
       pagy = Pagy.new count: 1000, page: 6
       pagy_countless = Pagy::Countless.new(page: 6).finalize(21)
-      _(view.pagy_prev_link(pagy)).must_equal "<span class=\"page prev\"><a href=\"/foo?page=5\" rel=\"next\" aria-label=\"next\"  >&lsaquo;&nbsp;Prev</a></span>"
-      _(view.pagy_prev_link(pagy_countless)).must_equal "<span class=\"page prev\"><a href=\"/foo?page=5\" rel=\"next\" aria-label=\"next\"  >&lsaquo;&nbsp;Prev</a></span>"
+      _(view.pagy_prev_link(pagy)).must_equal "<span class=\"page prev\"><a href=\"/foo?page=5\" rel=\"prev\" aria-label=\"previous\"  >&lsaquo;&nbsp;Prev</a></span>"
+      _(view.pagy_prev_link(pagy_countless)).must_equal "<span class=\"page prev\"><a href=\"/foo?page=5\" rel=\"prev\" aria-label=\"previous\"  >&lsaquo;&nbsp;Prev</a></span>"
     end
 
     it 'renders the prev link for last page' do
       pagy = Pagy.new count: 1000, page: 50
       pagy_countless = Pagy::Countless.new(page: 50).finalize(20)
-      _(view.pagy_prev_link(pagy)).must_equal "<span class=\"page prev\"><a href=\"/foo?page=49\" rel=\"next\" aria-label=\"next\"  >&lsaquo;&nbsp;Prev</a></span>"
-      _(view.pagy_prev_link(pagy_countless)).must_equal "<span class=\"page prev\"><a href=\"/foo?page=49\" rel=\"next\" aria-label=\"next\"  >&lsaquo;&nbsp;Prev</a></span>"
+      _(view.pagy_prev_link(pagy)).must_equal "<span class=\"page prev\"><a href=\"/foo?page=49\" rel=\"prev\" aria-label=\"previous\"  >&lsaquo;&nbsp;Prev</a></span>"
+      _(view.pagy_prev_link(pagy_countless)).must_equal "<span class=\"page prev\"><a href=\"/foo?page=49\" rel=\"prev\" aria-label=\"previous\"  >&lsaquo;&nbsp;Prev</a></span>"
     end
 
   end
@@ -140,4 +140,3 @@ describe Pagy::Frontend do
   end
 
 end
-


### PR DESCRIPTION
Changes made:

- the `rel` attribute has been changed from `next` to `prev`
- the `aria-label` attribute has been changed from `next` to `previous`
- the associated tests have been updated

I chose not to abbreviate the aria label as it's intended for screen readers, etc. In fact, `aria-labelledby` might be a better alternative as we already provide a description within the anchor text itself. But I decided not to address that issue in this PR.