### PR TITLE
Remove ordering for collection before getting count

### DIFF
--- a/lib/pagy/backend.rb
+++ b/lib/pagy/backend.rb
@@ -18,7 +18,10 @@ class Pagy
 
     # Sub-method called only by #pagy: here for easy customization of variables by overriding
     def pagy_get_vars(collection, vars)
-      vars[:count] ||= (c = collection.count(:all)).is_a?(Hash) ? c.size : c
+      unless vars[:count]
+        collection = collection.reorder(nil) if collection.respond_to?(:reorder)
+        vars[:count] = (c = collection.count(:all)).is_a?(Hash) ? c.size : c
+      end
       vars[:page]  ||= params[ vars[:page_param] || VARS[:page_param] ]
       vars
     end

--- a/test/mock_helpers/collection.rb
+++ b/test/mock_helpers/collection.rb
@@ -30,6 +30,10 @@ class MockCollection < Array
     []
   end
 
+  def reorder(order)
+    self
+  end
+
   class Grouped < MockCollection
 
     def count(*)


### PR DESCRIPTION
When a order is present it can break count calls. See: https://github.com/rails/rails/issues/33719.

I'm not sure if this is too specific to ActiveRecord for this class. But I have a handful of places I need to manually remove the order and pass in the count to avoid an error.