### PR TITLE
Add Swahili (sw) to pagy

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ Besides the classic pagination offered by the `pagy_nav` helpers, you can use a 
 - [Quick guide for Pagy with Sinatra and Sequel](https://medium.com/@vfreefly/how-to-use-pagy-with-sequel-and-sinatra-157dfec1c417) by Victor Afanasev
 - [Integrating Pagy with Hanami](http://katafrakt.me/2018/06/01/integrating-pagy-with-hanami/) by Paweł Świątkowski
 - [Stateful Tabs with Pagy](https://www.imaginarycloud.com/blog/how-to-paginate-ruby-on-rails-apps-with-pagy) by Chris Seelus
-- [Handling Pagination When POSTing Complex Search Forms](https://bkspurgeon.github.io/2019/10/09/paginating-search-results-with-a-post-request.html) by Ben Koshy.
-- [How to Override pagy methods only in specific circumstances](https://bkspurgeon.github.io/2020/02/01/overriding-pagy-methods.html) by Ben Koshy.
-- [How to make your pagination links sticky + bounce at the bottom of your page](https://bkspurgeon.github.io/2020/09/15/sticky-menu.html) by Ben Koshy.
+- [Handling Pagination When POSTing Complex Search Forms](https://benkoshy.github.io/2019/10/09/paginating-search-results-with-a-post-request.html) by Ben Koshy.
+- [How to Override pagy methods only in specific circumstances](https://benkoshy.github.io/2020/02/01/overriding-pagy-methods.html) by Ben Koshy.
+- [How to make your pagination links sticky + bounce at the bottom of your page](https://benkoshy.github.io/2020/09/15/sticky-menu.html) by Ben Koshy.
 - [日本語の投稿](https://qiita.com/search?q=pagy)
 - [한국어 튜토리얼](https://kbs4674.tistory.com/72)
 

--- a/lib/locales/sw.yml
+++ b/lib/locales/sw.yml
@@ -1,0 +1,22 @@
+# :one_other pluralization
+
+sw:
+  pagy:
+
+    item_name:
+      one: "kifaa"
+      other: "vifaa"
+
+    nav:
+      prev: "&lsaquo;&nbsp;Awali"
+      next: "Ifuatayo&nbsp;&rsaquo;"
+      gap: "&hellip;"
+
+    info:
+      no_items: "Hamna %{item_name} vilivyopatikana"
+      single_page: "Inaonyesha %{item_name} <b>%{count}</b>"
+      multiple_pages: "Inaonyesha %{item_name} <b>%{from}-%{to}</b> ya <b>%{count}</b> kwa jumla"
+
+    combo_nav_js: "Kurasa %{page_input} ya %{pages}"
+
+    items_selector_js: "Onyesha %{items_input} %{item_name} kwa kila ukurasa"


### PR DESCRIPTION
This translation to Swahili was originally created by Antony Oduor.
It was originally created for the CII Best Practices badge project at
https://github.com/coreinfrastructure/best-practices-badge and was
released using the MIT license, so there are no known licensing issues.

The CII Best Practices badge project uses pagy; we hope submitting this
translation upstream will help others support Swahili.
It's worth noting that pagy itself has earned a
[passing badge](https://bestpractices.coreinfrastructure.org/en/projects/4329).

The Swahili language uses
::RailsI18n::Pluralization::OneOther.with_locale(:sw) as noted in
https://github.com/svenfuchs/rails-i18n/blob/master/rails/pluralization/sw.rb

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>