### PR TITLE
Ruby 3 compatibility for Pagy::Search and Searchkick extra

### DIFF
--- a/lib/pagy/extras/searchkick.rb
+++ b/lib/pagy/extras/searchkick.rb
@@ -26,7 +26,7 @@ class Pagy
       vars                       = pagy_searchkick_get_vars(nil, vars)
       search_args[-1][:per_page] = vars[:items]
       search_args[-1][:page]     = vars[:page]
-      results                    = model.search(*search_args, &block)
+      results                    = pagy_searchkick_get_results(model, search_args, block)
       vars[:count]               = results.total_count
       pagy = Pagy.new(vars)
       # with :last_page overflow we need to re-run the method in order to get the hits
@@ -42,6 +42,19 @@ class Pagy
       vars[:items] ||= VARS[:items]
       vars[:page]  ||= (params[ vars[:page_param] || VARS[:page_param] ] || 1).to_i
       vars
+    end
+
+    if RUBY_VERSION.start_with?('3.')
+      eval <<-RUBY
+        def pagy_searchkick_get_results(model, search_args, block)
+          options = search_args.pop
+          model.search(*search_args, **options, &block)
+        end
+      RUBY
+    else
+      def pagy_searchkick_get_results(model, search_args, block)
+        model.search(*search_args, &block)
+      end
     end
 
   end


### PR DESCRIPTION
When using Pagy together with Searchkick in Ruby 3, there is an ArgumentError raised. This is because Pagy::Search has been using an options hash, while Searchkick expects keyword arguments to be used on the method call. In previous Ruby versions, Ruby did some magic to auto-convert the last argument to keyword args if it is an Hash. This is no longer the case in Ruby 3.

The failure can be seen in this minimal Rails application: https://github.com/tosch/pagy-searchkick-minimal-rails

This fix captures any keyword arguments given to Pagy::Search#pagy_search and ensures they are being used correctly when either using Elasticsearch (which expects an options hash as argument) or using Searchkick (which accepts an optional search term and keyword arguments).

With those changes applied, the above minimal Rails application works as expected.