### PR TITLE
Add Serbian language translation

### DIFF
--- a/lib/locales/sr.yml
+++ b/lib/locales/sr.yml
@@ -1,0 +1,23 @@
+# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/locales/utils/p11n.rb)
+
+sr:
+  pagy:
+    item_name:
+      one: "ставка"
+      few: "ставкe"
+      many: "ставки"
+      other: "ставки"
+
+    nav:
+      prev: "&lsaquo;&nbsp;Претходна"
+      next: "Следећa &nbsp;&rsaquo;"
+      gap: "&hellip;"
+
+    info:
+      no_items: "Нema пронађених %{item_name}"
+      single_page: "Приказује се <b>%{count}</b> %{item_name}"
+      multiple_pages: "Приказ %{item_name} <b>%{from}-%{to}</b> од <b>%{count}</b> укупно"
+
+    combo_nav_js: "Страниca %{page_input} од %{pages}"
+
+    items_selector_js: "Прикажи %{items_input} %{item_name} по страниcи"

--- a/lib/locales/utils/p11n.rb
+++ b/lib/locales/utils/p11n.rb
@@ -75,6 +75,7 @@ plurals = Hash.new(p11n[:one_other]).tap do |hash|
   hash['ko']    = p11n[:other]
   hash['pl']    = p11n[:polish]
   hash['ru']    = p11n[:east_slavic]
+  hash['sr']    = p11n[:east_slavic]
   hash['sv']    = p11n[:one_two_other]
   hash['sv-SE'] = p11n[:one_two_other]
   hash['tr']    = p11n[:other]


### PR DESCRIPTION
Hello.

Here's the Serbian locale.  For `no_items` the sentence will be written in a different way depending on the count of items. 
For example:

- one item:  "Није пронађенa %{item_name}"
- multiple items: "Нema пронађених %{item_name}"

Is there a way to use one or the other depending on the count?

😃 
