### PR TITLE
Fix Tailwind docs

### DIFF
--- a/docs/extras/tailwind.md
+++ b/docs/extras/tailwind.md
@@ -15,40 +15,40 @@ Copy and customize the following basic rules to apply the styles to the pagy CSS
 .pagy-nav, 
 .pagy-nav-js,
 .pagy-combo-nav-js {
-  @apply .inline-flex .shadow-md;
+  @apply inline-flex shadow-md;
 }
 .pagy-nav.pagination, 
 .pagy-nav-js.pagination,
 .pagy-combo-nav-js.pagination {
-  @apply .border .border-gray-600 .rounded-sm;
+  @apply border border-gray-600 rounded-sm;
 }
 .pagy-nav .page,
 .pagy-nav-js .page,
 .pagy-combo-nav-js .page,
 .pagy-combo-nav-js .pagy-combo-input {
-  @apply .text-gray-700 .border-r .border-gray-600 .px-3 .py-2 .text-sm .leading-tight .font-medium;
+  @apply text-gray-700 border-r border-gray-600 px-3 py-2 text-sm leading-tight font-medium;
 }
 .pagy-nav .page:hover,
 .pagy-nav-js .page:hover {
-  @apply .text-gray-900;
+  @apply text-gray-900;
 }
 .pagy-nav .disabled,
 .pagy-nav-js .disabled,
 .pagy-combo-nav-js .disabled {
-  @apply .cursor-not-allowed;
+  @apply cursor-not-allowed;
 }
 .pagy-nav .active,
 .pagy-nav-js .active {
-  @apply .text-blue-500;
+  @apply text-blue-500;
 }
 .pagy-nav .prev,
 .pagy-nav-js .prev,
 .pagy-combo-nav-js .prev {
-  @apply .text-gray-900;
+  @apply text-gray-900;
 }
 .pagy-nav .next,
  .pagy-nav-js .next,
  .pagy-combo-nav-js .next {
-  @apply .text-gray-900 .border-r .border-transparent;
+  @apply text-gray-900 border-r border-transparent;
 }
 ```


### PR DESCRIPTION
Tailwind's `@apply` directive works by taking the utility class name without a `.` in front. For reference, here's the [Tailwind v2 `@apply` examples](https://tailwindcss.com/docs/extracting-components#extracting-component-classes-with-apply). Same for Tailwind v1.

This PR makes the base styles proposed in the docs for Tailwind CSS users work directly on copy-pasting, doesn't change any of the styles.

Prevents the following error:
```
15:22:48 webpack.1 | ModuleBuildError: Module build failed (from ./node_modules/postcss-loader/dist/cjs.js):
15:22:48 webpack.1 | SyntaxError
15:22:48 webpack.1 |
15:22:48 webpack.1 | (4:2) /Users/thomasklemm/Code/Ashla/sunrise/app/javascript/stylesheets/components/_pagination.scss The `.inline-flex` class does not exist, but `inline-flex` does. If you're sure that `.inline-flex` exists, make sure that any `@import` statements are being properly processed before Tailwind CSS sees your CSS, as `@apply` can only be used for classes in the same CSS tree.
15:22:48 webpack.1 |
15:22:48 webpack.1 |   2 | .pagy-nav-js,
15:22:48 webpack.1 |   3 | .pagy-combo-nav-js {
15:22:48 webpack.1 | > 4 |   @apply .inline-flex .shadow-md;
15:22:48 webpack.1 |     |  ^
15:22:48 webpack.1 |   5 | }
```