### PR TITLE
Fix syntax error

### DIFF
--- a/lib/pagy.rb
+++ b/lib/pagy.rb
@@ -7,7 +7,9 @@ require 'pathname'
 class Pagy ; VERSION = '4.1.0'
 
   # Root pathname to get the path of Pagy files like templates or dictionaries
-  def self.root = @root ||= Pathname.new(__FILE__).dirname.freeze
+  def self.root
+    @root ||= Pathname.new(__FILE__).dirname.freeze
+  end
 
   # default vars
   VARS = { page:1, items:20, outset:0, size:[1,4,4,1], page_param: :page, params:{}, anchor:'', link_extra:'', i18n_key:'pagy.item_name', cycle:false }


### PR DESCRIPTION
```
% ruby -v
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-openbsd]
% bundle install
[!] There was an error while loading `pagy.gemspec`: /home/cloud69420/.gem/bundler/gems/pagy-c178c6f63bdd/lib/pagy.rb:10: syntax error, unexpected '=', expecting ';' or '\n'
  def self.root = @root ||= Pathname.new(__FIL...
                ^
/home/cloud69420/.gem/bundler/gems/pagy-c178c6f63bdd/lib/pagy.rb:13: dynamic constant assignment
  VARS = { page:1, items:20, outset...
  ^~~~
. Bundler cannot continue.

 #  from /home/cloud69420/.gem/bundler/gems/pagy-c178c6f63bdd/pagy.gemspec:3
 #  -------------------------------------------
 #  $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 >  require 'pagy'
 #
 #  -------------------------------------------
```