### PR TITLE
CI: Remove Bundler 1.x workaround

### DIFF
--- a/ci-gemfiles/ruby-3.0
+++ b/ci-gemfiles/ruby-3.0
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-
 gem 'rake'
 gem 'rack'
 gem 'i18n'


### PR DESCRIPTION
The "github" source now has that form, already.

This PR only serves to simplify that Gemfile.