### PR TITLE
fix(pagy): deprecated_var is a class method

### DIFF
--- a/lib/pagy.rb
+++ b/lib/pagy.rb
@@ -23,7 +23,7 @@ class Pagy
   # Merge and validate the options, do some simple arithmetic and set the instance variables
   def initialize(vars)
     @vars = VARS.merge( vars.delete_if{|k,v| VARS.key?(k) && (v.nil? || v == '') } )
-    @vars[:fragment] = deprecated_var(:anchor, @vars[:anchor], :fragment, @vars[:fragment]) if @vars[:anchor]
+    @vars[:fragment] = Pagy.deprecated_var(:anchor, @vars[:anchor], :fragment, @vars[:fragment]) if @vars[:anchor]
 
     INSTANCE_VARS_MIN.each do |name,min|
       raise VariableError.new(self), "expected :#{name} >= #{min}; got #{@vars[name].inspect}" \


### PR DESCRIPTION
Otherwise it will trigger an exception like: 
> ActionView::Template::Error: undefined method `deprecated_var' for #<Pagy:0x00007f613c196028>
