### PR TITLE
chore: add github action - publish & tag versions

### DIFF
--- a/.github/workflows/publish-gem-and-tag.yml
+++ b/.github/workflows/publish-gem-and-tag.yml
@@ -1,0 +1,56 @@
+
+# What does this action do?
+
+# This Github Action allows for: 
+#   (i) the publishing of the gem to ruby gems.
+#   (ii) automatic tagging of the default branch. 
+# The action is triggered through a manual action - click and run (i.e. through workflow_dispatch)
+# The default branch is assumed.
+
+# The version number of pagy is located in two distinct files: the lib/pagy.rb file and also the
+# lib/javascripts/pagy.js file. 
+
+# Ruby gems publishes the version number located in the pagy.rb file, while we tag the default 
+# branch using the version located in the pagy.js file. both versions listed in those two file smust be kept 
+# in sync to avoid confusion.
+
+name: publish-gem-and-tag
+on: 
+  workflow_dispatch:    
+
+jobs:
+  publish-gem-and-tag:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v2  # checks out default branch
+      
+      - uses: ruby/setup-ruby@v1
+        with:          
+          ruby-version: 3.0.0      
+      - run: bundle install      
+
+      - name: publish gem
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:          
+          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"     
+
+      - name: Create tag
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require("fs")
+            eval(fs.readFileSync("./lib/javascripts/pagy.js").toString())
+            
+            github.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${Pagy.version}`,
+              sha: context.sha
+            })

--- a/lib/javascripts/pagy.js
+++ b/lib/javascripts/pagy.js
@@ -114,4 +114,8 @@ Pagy.waitForMe =
     Pagy.tid = setTimeout(Pagy.renderNavs, Pagy.delay)
   }
 
-window.addEventListener('resize', Pagy.waitForMe, true)
+
+if (typeof window !== "undefined") {
+  window.addEventListener('resize', Pagy.waitForMe, true)
+}
+


### PR DESCRIPTION
### What is this?

This commit allows for the automation of: (i) publishing ruby gems, and (ii) if the gem is successfully published, tagging the branch with pertinent version.

### How does it work?

 * The gem is bundled and pushed to ruby gems with a simple script. 
 * The tagging occurs based on the version contained in the pagy.js file. It is absolutely essential that both the pagy.rb  and pagy.js file have the same version numbers otherwise confusion might result.

### How do I run it?

 * First increment the versions in both the pagy.rb and pagy.js
    files.
 * Manually run the action from the actions tab in github.com.

![image](https://user-images.githubusercontent.com/15097447/127798386-bad46ddd-3ed3-4dd5-8a6e-275a0f84184f.png)


 * You will also need to add github secrets, an API key to authenticate the publishing to ruby gems. Please call it `RUBYGEMS_AUTH_TOKEN`.


![image](https://user-images.githubusercontent.com/15097447/127798521-3b31ae05-6c1a-4182-a1e0-8c79dea37728.png)


### Why?

  * To hopefully make things a little faster and easier.

### Why has a conditional been added to the pagy.js file?

 * We are using a node based script to run a 'step' which tags the default branch with the gem's version number. This revision    number is extracted from the pagy.js file. That file has a 'window' variable contained in it. But node has no concept of a 'window' variable. Granted, a dummy window variable can be added to the node script, but I opted for a conditional, out of convenience.

* We wanted to make the pagy.js file work for all browsers. It would not do for us to simply add a default export line to the pagy.js to extract the version number, because it would not be widely supported across all browsers. Hence, in this action we are reading the pagy.js file and then eval-ing it. Making the version number readily available to us.