### PR TITLE
Add: link directly to docs page

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -16,7 +16,7 @@
 <body>
 <div class="wrapper">
 
-  <a href="https://github.com/ddnexus/pagy" class="github-corner" title="View source on Github"
+  <a href="{{site.github.repository_url}}/blob/master/docs/{{page.path}}" class="github-corner" title="View source on Github"
      aria-label="View source on Github">
     <svg width="80" height="80" viewBox="0 0 250 250"
          style="fill:#828B94; color:#f7f7f7; position: fixed; top: 0; border: 0; right: 0; opacity:0.3"


### PR DESCRIPTION
### What / Why this PR?

Right now, if someone wants to update the docs page, they have to go to the repo and manually find the page.

When they click on the link, it would be nice if they were directed to the actual page which they are required to edit. This PR attempts to fix that problem.

![image](https://user-images.githubusercontent.com/15097447/128597080-79c55c9a-0d5e-4dca-a5d2-3002984472cd.png)

**UPDATE:**

* I have built the site using `pagy-docker` and it looks good to me. Clicking the link will direct you to the relevant docs page where PRs against the master branch can be made in-line.