### PR TITLE
Remove minor extra parenthesis in trim docs

### DIFF
--- a/docs/extras/trim.md
+++ b/docs/extras/trim.md
@@ -55,6 +55,6 @@ This method overrides the `pagy_link_proc` using the `pagy_trim` to process the 
 
 Sub-method called only by the `pagy_link_proc` method, it removes the the `:page_param` param from the first page link (usually `page=1`).
 
-Override this method if you are [Customizing the urls](../how-to.md#customizing-the-url)).
+Override this method if you are [Customizing the urls](../how-to.md#customizing-the-url).
 
 If you use a `pagy_*nav_js`  helper you should customize the `Pagy.trim` javascript function instead.


### PR DESCRIPTION
Minor typo introduced in 7551521861ac70ffbbd34a645811464b0001c05d

![image](https://user-images.githubusercontent.com/132/129953308-321bf294-feb2-4c51-981e-5998134f96d4.png)
