### PR TITLE
Fix - link directly to docs

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -16,7 +16,7 @@
 <body>
 <div class="wrapper">
 
-  <a href="{{site.github.repository_url}}/blob/master/docs/{{page.path}}" class="github-corner" title="View source on Github"
+  <a href="https://github.com/ddnexus/pagy/blob/master/docs/{{page.path}}" class="github-corner" title="View source on Github"
      aria-label="View source on Github">
     <svg width="80" height="80" viewBox="0 0 250 250"
          style="fill:#828B94; color:#f7f7f7; position: fixed; top: 0; border: 0; right: 0; opacity:0.3"


### PR DESCRIPTION
### Why this PR

  * to make it easy for people to contribute: click, emend,
    and submit. No need fork / download / search for .md file.
  * to reduce maintenance burden (saving time) on issues.
  * Fixes: #324 - github's url value was unexpected:
    https://jekyll.github.io/github-metadata/site.github/
    so i simply hardcoded it in and tested a direct link
    via docker. it looks good to me now.

Apologies for the error.