### PR TITLE
docs: add tutorial, simplify header

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ See also the [How To Page](http://ddnexus.github.io/pagy/how-to)
 
 <details>
 
-<summary>Read some interesting post and tutorial...</summary>
+<summary> Posts and tutorials...</summary>
 
 - [Migrate from WillPaginate and Kaminari](https://ddnexus.github.io/pagy/migration-guide) (practical guide)
 - [Detailed Gems Comparison](https://ddnexus.github.io/pagination-comparison/gems.html) (charts and analysis)
@@ -285,6 +285,7 @@ See also the [How To Page](http://ddnexus.github.io/pagy/how-to)
 - [Quick guide for Pagy with Sinatra and Sequel](https://medium.com/@vfreefly/how-to-use-pagy-with-sequel-and-sinatra-157dfec1c417) by Victor Afanasev
 - [Integrating Pagy with Hanami](http://katafrakt.me/2018/06/01/integrating-pagy-with-hanami/) by Paweł Świątkowski
 - [Stateful Tabs with Pagy](https://www.imaginarycloud.com/blog/how-to-paginate-ruby-on-rails-apps-with-pagy) by Chris Seelus
+- [Pagination for Beginners: What is it? Why bother?](https://benkoshy.github.io/2021/11/03/pagination-basics.html) by Ben Koshy.
 - [Handling Pagination When POSTing Complex Search Forms](https://benkoshy.github.io/2019/10/09/paginating-search-results-with-a-post-request.html) by Ben Koshy.
 - [How to Override pagy methods only in specific circumstances](https://benkoshy.github.io/2020/02/01/overriding-pagy-methods.html) by Ben Koshy.
 - [How to make your pagination links sticky + bounce at the bottom of your page](https://benkoshy.github.io/2020/09/15/sticky-menu.html) by Ben Koshy.


### PR DESCRIPTION
Why this PR?

  - seeks to close out the discussion on #333 (https://github.com/ddnexus/pagy/pull/333)
and #338 (https://github.com/ddnexus/pagy/pull/338#issuecomment-960342618).

  - heading change: minor grammar - add pluralisation; also simplified
to make more laconic.