### PR TITLE
fix: uninitialized constant Pagy::MetadataExtra::Calendar

### DIFF
--- a/lib/pagy/extras/metadata.rb
+++ b/lib/pagy/extras/metadata.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'pagy/url_helpers'
+require 'pagy/extras/calendar'
 
 class Pagy # :nodoc:
   DEFAULT[:metadata] = %i[ scaffold_url first_url prev_url page_url next_url last_url


### PR DESCRIPTION
## Issue

After upgrading from v5.1.3 to v5.2.1, I got the following error.

```
      NameError:
        uninitialized constant Pagy::MetadataExtra::Calendar
```

It seems to be happening because the next line refers to Calendar.
https://github.com/ddnexus/pagy/blob/5.2.1/lib/pagy/extras/metadata.rb#L20

## Solution

add: require 'pagy/extras/calendar' to metadata.rb


--

If it should be initialized at the same time as metadata, then close this PR.
ex) config/initializers/pagy.rb
```ruby
require 'pagy/extras/metadata'
require 'pagy/extras/calendar'
```

## Version
 - Ruby: 2.7.4
 - Rails: 5.2.4.4
 - Pagy: 5.2.1