### PR TITLE
Add Tamil (ta) translation

### DIFF
--- a/lib/locales/ta.yml
+++ b/lib/locales/ta.yml
@@ -1,0 +1,22 @@
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/locales/utils/p11n.rb)
+
+ta:
+  pagy:
+
+    item_name:
+      one: "பதிவு"
+      other: "பதிவுகள்"
+
+    nav:
+      prev: "&lsaquo;&nbsp;முந்தையது"
+      next: "அடுத்தது&nbsp;&rsaquo;"
+      gap: "&hellip;"
+
+    info:
+      no_items: "%{item_name} கிடைக்கவில்லை"
+      single_page: "<b>%{count}</b> %{item_name} காட்டப்படுகின்றது"
+      multiple_pages: "மொத்தம் <b>%{count}</b> %{item_name}, காட்டப்படுபவை <b>%{from}-%{to}</b>"
+
+    combo_nav_js: "<label>%{pages}-இல் %{page_input}-வது பக்கம்</label>"
+
+    items_selector_js: "<label>ஒரு பக்கத்திற்கு %{items_input} %{item_name} காட்டு</label>"


### PR DESCRIPTION
Came across this gem when I was developing an application with Tamil language support. I've already added translation to the necessary (pagy) strings inside my application. Sharing the translations here!

The pluralization rule for Tamil is `OneOther`. But I did not find the pluralization rule file in [rails-i18n list](https://github.com/svenfuchs/rails-i18n/tree/master/rails/pluralization). If it's needed, I'd be happy to raise a PR there too to include the pluralization rule. 

P.S. If any fellow Tamil-speaker comes across this, feel free to correct me if the translations can be improved!