### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/pagy-ci.yml
+++ b/.github/workflows/pagy-ci.yml
@@ -47,6 +47,10 @@ jobs:
               BUNDLE_GEMFILE: .github/gemfiles/ruby-2.5+
               CODECOV: true
               CHECK_MANIFEST: true
+          - ruby-version: '3.1'
+            env:
+              BUNDLE_GEMFILE: .github/gemfiles/ruby-2.5+
+              RUBYOPT: '--disable-error_highlight'
       fail-fast: false
     env: ${{ matrix.env }}
 

--- a/test/mock_helpers/collection.rb
+++ b/test/mock_helpers/collection.rb
@@ -51,7 +51,11 @@ class MockCollection < Array
     START_DATE = Time.new(2021, 10, 21, 13, 18, 23).utc
     END_DATE   = Time.new(2023, 11, 13, 15, 43, 40).utc
     YAML_FILE  = File.expand_path('../files/calendar_collection.yml', __dir__)
-    COLLECTION = YAML.load_file YAML_FILE
+    COLLECTION = if Psych::VERSION > '4.0'
+                   YAML.safe_load(File.read(YAML_FILE), permitted_classes: [Time])
+                 else
+                   YAML.safe_load(File.read(YAML_FILE), [Time], [])
+                 end
 
     def initialize(arr = COLLECTION)
       super


### PR DESCRIPTION
This PR adds Ruby 3.1 to CI.

Other than the relatively obvious change to the CI configuration there are two other changes:

1. Setting the '--disable-error_highlight' RUBYOPT so that we don't get error highlighting in error messages in test
2. Updating Psych to explicitly permit instances of the Time class when loading YAML in the mocks.