### PR TITLE
Fix for wrong calculation of local time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ If you upgrade from version `< 5.0.0` see the following:
 Still supported in version `5.x` but not supported from `6.0` on:
 
 - `pagy_massage_params` method: use the `:params` variable set to a lambda `Proc` that does the same (but per instance). See [How to customize the params](https://ddnexus.github.io/pagy/how-to#customize-the-params).
-
+- `Pagy::Calendar::*` instances: The `:period` variable must contain UTC Time objects (it was local time), besides you must set the `:in_local_time` proc variable that receives a UTC object and returns a local Time object. See [Calendar extra](https://ddnexus.github.io/pagy/extras/calendar).
 <hr>
 
 ## Version 5.8.1

--- a/docs/api/calendar.md
+++ b/docs/api/calendar.md
@@ -21,12 +21,13 @@ Being subclasses of `Pagy`, the `Pagy::Calendar::*` classes share most of their 
 
 The following variables are specific to `Pagy::Calendar::*` instances: 
 
-| Variable  | Description                                                                                               | Default |
-|:----------|:----------------------------------------------------------------------------------------------------------|:--------|
-| `:period` | Required two items Array with the calendar starting and ending local `Time` objects                       | `nil`   |
-| `:order`  | Order of pagination: it can be`:asc` or `:desc`                                                           | `:asc`  |
-| `:format` | String containing the `strftime` extendable format used for labelling (each subclass has its own default) |         |
-| `:offset` | Day offset from Sunday (0: Sunday; 1: Monday;... 6: Saturday) (`Pagy::Calendar::Week` only)               | `0`     |
+| Variable        | Description                                                                                               | Default |
+|:----------------|:----------------------------------------------------------------------------------------------------------|:--------|
+| `:in_time_zone` | Required proc to convert UTC time to local time (e.g. `->(utc) { utc.in_time_zone.to_time }`              | `nil`   |
+| `:period`       | Required two items Array with the calendar starting and ending UTC `Time` objects                         | `nil`   |
+| `:order`        | Order of pagination: it can be`:asc` or `:desc`                                                           | `:asc`  |
+| `:format`       | String containing the `strftime` extendable format used for labelling (each subclass has its own default) |         |
+| `:offset`       | Day offset from Sunday (0: Sunday; 1: Monday;... 6: Saturday) (`Pagy::Calendar::Week` only)               | `0`     |
 
 **Notice**: For the `Pagy::Calendar::Quarter` the `:format` variable can contain a non-standard `%q` format which is substituted with the quarter (1-4).
 
@@ -38,8 +39,8 @@ The calendar defaults are not part of the `Pagy::DEFAULT` variables. Each subcla
 
 | Reader   | Description                                                    |
 |:---------|:---------------------------------------------------------------|
-| `from`   | The local `Time` of the start of the current page              |
-| `to`     | The local `Time` of the end of the current page                |
+| `from`   | The UTC `Time` of the start of the current page                |
+| `to`     | The UTC `Time` of the end of the current page                  |
 | `offset` | The `:offset` variable of the `Pagy::Calendar::Week` instances |
 | `order`  | The `:order` variable                                          |
 
@@ -54,15 +55,7 @@ The cases for first and last pages have no effect when you use the `from`/`to` a
 
 This classes use only the ruby `Time` class for all their time calculations for great performance without dependencies.
 
-Since they are meant to be used in the UI, they have to do their internal calculation using the user/server local time in order to make sense for the UI. For that reason their input/output is always local time.
-
-If you use `ActiveRecord`, your app should set the `Time.zone` for your user or your server. Then you can convert an UTC time from the storage to a local `Time` object for the calendar very easily with:
-
-```ruby
-utc_time.in_time_zone.to_time
-```
-
-You can also convert from local `Time` object to a UTC time with `local_time.utc`, however, when you use it as an argument in a scope, `ActiveRecord` converts it for you.
+All the`Pagy::Calendar::*` input, output and internal calculations are represented in UTC Time. However since the helpers are meant to be used in the UI, you have to provide the `:in_time_zone` Proc variable to convert the UTC time argument and return the local time. For example: `in_time_zone: ->(utc) { utc.in_time_zone.to_time }`. In the rare case you don't use time conversion at all you can set the proc to `->(t){t}` (i.e. returning the same time that has been passed).
 
 For general usage without `ActiveRecord` you can simply use the `Time` methods to convert `utc_time.getlocal(utc_offset)` and `local_time.utc`.
 

--- a/lib/pagy/calendar/quarter.rb
+++ b/lib/pagy/calendar/quarter.rb
@@ -14,9 +14,9 @@ class Pagy # :nodoc:
 
       # The label for any page, with the substitution of the '%q' token
       def label_for(page, opts = {})
-        starting_time = starting_time_for(page.to_i)  # page could be a string
-        opts[:format] = (opts[:format] || @vars[:format]).gsub('%q') { (starting_time.month / 4) + 1 }
-        localize(starting_time, opts)
+        local = @in_time_zone.call(starting_time_for(page.to_i))  # page could be a string
+        opts[:format] = (opts[:format] || @vars[:format]).gsub('%q') { (local.month / 4) + 1 }
+        localize(local, opts)
       end
     end
   end

--- a/lib/pagy/extras/calendar.rb
+++ b/lib/pagy/extras/calendar.rb
@@ -31,9 +31,10 @@ class Pagy # :nodoc:
 
         page_param = conf[:pagy][:page_param] || DEFAULT[:page_param]
         units.each do |unit|  # set all the :page_param vars for later deletion
-          unit_page_param         = :"#{unit}_#{page_param}"
-          conf[unit][:page_param] = unit_page_param
-          conf[unit][:page]       = params[unit_page_param]
+          unit_page_param           = :"#{unit}_#{page_param}"
+          conf[unit][:page_param]   = unit_page_param
+          conf[unit][:page]         = params[unit_page_param]
+          conf[unit][:in_time_zone] = conf[:in_time_zone]
         end
         calendar = {}
         last_obj = nil


### PR DESCRIPTION
**IT PROBABLY DOES NOT WORK AND MUST BE REIMPLEMENTED**

Sorry no time to try it properly, so I have to guess for now. The conversion to UTC to local must be done when creating a new Time object, in order to find e.g. the start of the month for that time zone. The implementation in this branch creates the start of the periods in UTC and then converts the labels in local, which means that the local time is indicating a start of the month for UTC which translates to a local start of the month that has an offset.

---
- All Time input, output and calculations are expressed in UTC time now (e.g. `:period`, `from` and `to`)
- The `label_for` method calls the `:in_time_zone` user-defined proc variable in order to correctly convert the labels to local time
- The old incorrect code is deprecated but still supported till 6.0 in order to avoid breaking apps that may work without problems

### TO DO
- Tests for new code (old tests pass)
- Update `apps/pagy_calendar_app.ru`
- Review doc