### PR TITLE
add: ms_search alias to prevent conflict method name conflict

### DIFF
--- a/docs/extras/meilisearch.md
+++ b/docs/extras/meilisearch.md
@@ -20,7 +20,7 @@ require 'pagy/extras/meilisearch'
 If you have an already paginated `Meilisearch` results, you can get the `Pagy` object out of it:
 
 ```ruby
-@results = Model.search(nil, offset: 10, limit: 10, ...)
+@results = Model.ms_search(nil, offset: 10, limit: 10, ...)
 @pagy    = Pagy.new_from_meilisearch(@results, ...)
 ```
 
@@ -52,7 +52,7 @@ results         = Article.pagy_search(params[:q])
 This constructor accepts a Meilisearch as the first argument, plus the usual optional variable hash. It sets the `:items`, `:page` and `:count` pagy variables extracted/calculated out of the Meilisearch object.
 
 ```ruby
-@results = Model.search(nil, offset: 10, limit: 10, ...)
+@results = Model.ms_search(nil, offset: 10, limit: 10, ...)
 @pagy    = Pagy.new_from_meilisearch(@results, ...)
 ```
 

--- a/lib/pagy/extras/meilisearch.rb
+++ b/lib/pagy/extras/meilisearch.rb
@@ -35,7 +35,7 @@ class Pagy # :nodoc:
         vars                 = pagy_meilisearch_get_vars(nil, vars)
         options[:limit]      = vars[:items]
         options[:offset]     = (vars[:page] - 1) * vars[:items]
-        results              = model.search(term, **options)
+        results              = model.ms_search(term, **options)
         vars[:count]         = results.raw_answer['nbHits']
         pagy                 = ::Pagy.new(vars)
         # with :last_page overflow we need to re-run the method in order to get the hits

--- a/test/mock_helpers/meilisearch.rb
+++ b/test/mock_helpers/meilisearch.rb
@@ -28,6 +28,10 @@ module MockMeilisearch
       Results.new(*args)
     end
 
+    def self.ms_search(*args)
+      search(*args)
+    end
+
     extend Pagy::Meilisearch
   end
 end

--- a/test/pagy/extras/meilisearch_test.rb
+++ b/test/pagy/extras/meilisearch_test.rb
@@ -86,7 +86,7 @@ describe 'pagy/extras/meilisearch' do
 
     describe 'Pagy.new_from_meilisearch' do
       it 'paginates results with defaults' do
-        results = MockMeilisearch::Model.search('a')
+        results = MockMeilisearch::Model.ms_search('a')
         pagy    = Pagy.new_from_meilisearch(results)
         _(pagy).must_be_instance_of Pagy
         _(pagy.count).must_equal 1000
@@ -94,7 +94,7 @@ describe 'pagy/extras/meilisearch' do
         _(pagy.page).must_equal 1
       end
       it 'paginates results with vars' do
-        results = MockMeilisearch::Model.search('b', limit: 15, offset: 30)
+        results = MockMeilisearch::Model.ms_search('b', limit: 15, offset: 30)
         pagy    = Pagy.new_from_meilisearch(results, link_extra: 'X')
         _(pagy).must_be_instance_of Pagy
         _(pagy.count).must_equal 1000


### PR DESCRIPTION
* fix:  #367 failing tests.

