### PR TITLE
Add: documentation changes

### DIFF
--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -63,12 +63,17 @@ Here is a screenshot (from the `bootstrap`extra) showing responsiveness at diffe
 
 ## Installation instructions
 
-1. Add the relevant extra
-2. Use JS helper in a View
+1. Load the Javascript assets.
+2. Add the relevant extra
+3. Use JS helper in a View
 
 See [extras](../extras.md) for general usage info.
 
-#### 1. Add the relevant extra
+#### 1. Load / Initialise Pagy Javascript
+
+The strategy might vary, depending on what you're using: sprockets / or bundlers like (webpack-esbuild-rollup etc) / importmaps / propshaft etc - see [Javascript Readme Instructions](https://github.com/ddnexus/pagy/blob/master/lib/javascripts/README.md) for installation and initialization details.
+
+#### 2. Add the relevant extra
 
 In the `pagy.rb` initializer, require the specific extra for the style you want to use:
 
@@ -83,7 +88,9 @@ require 'pagy/extras/semantic'
 require 'pagy/extras/uikit'
 ```
 
-#### 2. Use the JS helper in a View
+This will make available, the below helpers:
+
+#### 3. Use the JS helper in a View
 
 Use one of the `pagy*_nav_js` helpers in any view:
 

--- a/lib/javascripts/README.md
+++ b/lib/javascripts/README.md
@@ -85,13 +85,15 @@ window.addEventListener('load', Pagy.init);
 
 Ensure the `Pagy.root.join('javascripts', 'pagy.js')` script gets served with the page.
 
-### Rails asset pipeline
+
+### Rails Apps
+
+Trouble-shooting your javascript installation on Rails? Some [of these rails demo apps](https://github.com/stars/benkoshy/lists/rails-demo-apps-for-pagy) may help (the commit diffs are structured to make it elementary).
 
 In `application.js`, require pagy and add an event listener like `"turbolinks:load"` or `"load"` that fires on page load:
 
 ```js
 //= require pagy
-
 window.addEventListener(YOUR_EVENT_LISTENER, Pagy.init);
 ```
 

--- a/lib/javascripts/README.md
+++ b/lib/javascripts/README.md
@@ -101,6 +101,25 @@ In `application.js`, require pagy and add an event listener like `"turbolinks:lo
 window.addEventListener(YOUR_EVENT_LISTENER, Pagy.init);
 ```
 
+Or you can do so using Stimulus JS:
+
+```js
+// pagy_initializer_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    Pagy.init(this.element)
+  }
+}
+```
+
+```html+erb
+<div data-controller="pagy-initializer">
+  <%== pagy_nav_js(@pagy) %>
+</div>
+```
+
 Uncomment the following line in `config/initializers/pagy.rb`:
 
 ```ruby
@@ -113,22 +132,19 @@ Rails.application.config.assets.paths << Pagy.root.join('javascripts')
 Rails.application.config.assets.paths << Pagy.root.join('javascripts')
 ```
 
-```html+erb
+```erb
 <-- e.g. appliciation.html.erb -->
 <%= javascript_include_tag "pagy" %>
 ```
 
-And initialize Pagy any way you like: 
-
-```js
-window.addEventListener(YOUR_EVENT_LISTENER, Pagy.init);
-```
+And initialize Pagy any way you like (as above).
 
 #### 2. Rails jsbundling-rails
 
 In `app/javascript/application.js`, import and use the pagy module: 
 
 ```js
+// or use stimulus JS above
 import Pagy from "pagy-module";
 window.addEventListener("turbo:load", Pagy.init);
 ```
@@ -204,6 +220,7 @@ export default {
 In `app/javascript/application.js`, import and use the pagy module:
 
 ```js
+// or use stimulus JS above
 import Pagy from "pagy-module";
 window.addEventListener("turbo:load", Pagy.init);
 ```
@@ -255,7 +272,6 @@ Create `app/javascript/packs/pagy.js.erb` with the following content:
 
 ```erb
 <%= Pagy.root.join('javascripts', 'pagy.js').read %>
-
 window.addEventListener(YOUR_EVENT_LISTENER, Pagy.init)
 ```
 

--- a/lib/javascripts/README.md
+++ b/lib/javascripts/README.md
@@ -90,6 +90,10 @@ Ensure the `Pagy.root.join('javascripts', 'pagy.js')` script gets served with th
 
 Trouble-shooting your javascript installation on Rails? Some [of these rails demo apps](https://github.com/stars/benkoshy/lists/rails-demo-apps-for-pagy) may help (the commit diffs are structured to make it elementary).
 
+#### 1. Rails asset pipeline
+
+##### Sprockets
+
 In `application.js`, require pagy and add an event listener like `"turbolinks:load"` or `"load"` that fires on page load:
 
 ```js
@@ -102,8 +106,25 @@ Uncomment the following line in `config/initializers/pagy.rb`:
 ```ruby
 Rails.application.config.assets.paths << Pagy.root.join('javascripts')
 ```
+##### Propshaft
 
-### Rails jsbundling-rails
+```ruby
+# config/initializers/pagy.rb
+Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+```
+
+```html+erb
+<-- e.g. appliciation.html.erb -->
+<%= javascript_include_tag "pagy" %>
+```
+
+And initialize Pagy any way you like: 
+
+```js
+window.addEventListener(YOUR_EVENT_LISTENER, Pagy.init);
+```
+
+#### 2. Rails jsbundling-rails
 
 In `app/javascript/application.js`, import and use the pagy module: 
 
@@ -118,7 +139,7 @@ Luckily, you can just configure your javascript tools to look into the `$(bundle
 
 Here is how to do that with different bundlers:
 
-#### Esbuild
+##### Esbuild
 
 In `package.json`, prepend the `NODE_PATH` environment variable to the `scripts.build` command:
 
@@ -128,7 +149,7 @@ In `package.json`, prepend the `NODE_PATH` environment variable to the `scripts.
 }
 ```
 
-#### Webpack
+##### Webpack
 
 In `package.json`, prepend the `PAGY_PATH` environment variable to the `scripts.build` command:
 
@@ -152,7 +173,7 @@ module.exports = {
 }
 ```
 
-#### Rollup
+##### Rollup
 
 In `package.json`, prepend the `PAGY_PATH` environment variable to the `scripts.build` command:
 
@@ -178,7 +199,7 @@ export default {
 }
 ```
 
-### Rails Importmap
+#### Rails Importmap
 
 In `app/javascript/application.js`, import and use the pagy module:
 

--- a/lib/javascripts/README.md
+++ b/lib/javascripts/README.md
@@ -8,7 +8,7 @@ These files are all providing the `Pagy` object and its only function `init`. Yo
 
 ### pagy-module.js
 
-The `pagy-module.js` is a ES6 module to use with webpacker, esbuild, parcel, etc. Import it with `import Pagy from "pagy-module"`.
+The [`pagy-module.js`](https://github.com/ddnexus/pagy/blob/master/lib/javascripts/pagy-module.js) is a ES6 module to use with webpacker, esbuild, parcel, etc. Import it with `import Pagy from "pagy-module"`.
  
 <details>
 
@@ -69,7 +69,7 @@ The `pagy.js` is a drop-in script meant to be loaded as is, directly in your pro
 
 <summary>pagy-dev.js (pagy debug only)</summary>
 
-The `pagy-dev.js` is a readable javascript file meant to be used as a drop-in file **only for debugging** with modern browsers. It won't work on old browsers and its size is big because it contains also the source map data to debug the TypeScript directly. Obviously... do not use it in production.
+The [`pagy-dev.js`](https://github.com/ddnexus/pagy/blob/master/lib/javascripts/pagy-dev.js) is a readable javascript file meant to be used as a drop-in file **only for debugging** with modern browsers. It won't work on old browsers and its size is big because it contains also the source map data to debug the TypeScript directly. Obviously... do not use it in production.
 
 </details>
 


### PR DESCRIPTION
Why?

* A series of changes to hopefully make things easier. A lot of them were based on my own experience to make (my) use of the gem and it's documentation super smooth.
* Added: stimulus js example because (i imagine) most Rails users would use it to initialize javascript.
* Commits are kept separate to enable easy tracking. I can squash if required. 

Please feel free to edit/remote as you wish.  I hope the community finds it helpful.
