### PR TITLE
update: pagy_bare_rails script: for db testing

### DIFF
--- a/apps/pagy_bare_rails.rb
+++ b/apps/pagy_bare_rails.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
-# Self-contained, bare rails app, usable to play with pagy
-# and/or easily reproduce any pagy issue.
+# Basic Rails app to: (i) reproduce errors, (ii) experiment pagy.
 
-# Edit this file as you need
-
-# USAGE:
+## Setup
+# 1. Install SqLite3 (an in-memory DB) e.g.
+##   sudo apt install sqlite3
+# 2. Optional: If using external services e.g. Meilisearch
+##    docker pull getmeili/meilisearch:latest # Fetch latest Meilisearch image from Docker Hub
+##    docker run -it --rm -p 7700:7700 getmeili/meilisearch:latest ./meilisearch -master-key=password
+# 4. Run script in separate terminal window:
 #     ruby pagy_bare_rails.rb
 
 # NOTICE: if you get any installation error(s) with the following setup
@@ -18,8 +21,7 @@ gemfile(true) do
   source 'https://rubygems.org'
 
   # Debuggers
-  # gem 'debug'
-
+  gem 'debug'
   # gem 'debase'
   # gem 'ruby-debug-ide'
 
@@ -30,16 +32,18 @@ gemfile(true) do
   gem 'rails', '~> 6.1'
   gem 'actionpack'
   gem 'railties'
+  gem 'sqlite3'
+
+  ## Optional: Meilisearch example
+  # gem 'meilisearch-rails'
 end
 
-# Set up debugging tools
-# require "debug" ## etc
+require 'debug'
 
-# pagy initializer - add your requirements here:
+## Pagy Set-up
 # https://ddnexus.github.io/pagy/extras
 # https://ddnexus.github.io/pagy/api/backend
-
-# Edit this section as you need
+require 'pagy/extras/meilisearch'
 require 'pagy/extras/metadata'
 require 'pagy/extras/overflow'
 require 'pagy/extras/trim'
@@ -52,7 +56,6 @@ Pagy::DEFAULT[:overflow] = :empty_page
 # Rails set up:
 require 'action_controller/railtie'
 require 'active_record'
-
 require 'minitest/autorun' # runs tests automatically
 
 class TestApp < Rails::Application # :nodoc:
@@ -68,18 +71,72 @@ class TestApp < Rails::Application # :nodoc:
   routes.draw do
     get '/' => 'test#index', as: 'test'
   end
+
+  ## Optional: Meilisearch example
+  #  MeiliSearch::Rails.configuration = {
+  #  meilisearch_host: 'http://localhost:7700',
+  #  meilisearch_api_key: 'password' }
 end
 
-class Record < ActiveRecord::Base; end # :nodoc:
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.connection.create_table(:authors) do |t|
+  t.text :name
+end
+
+ActiveRecord::Base.connection.create_table(:books) do |t|
+  t.text :name
+  t.references :author, foreign_key: true
+end
+
+ActiveRecord::Base.logger = Logger.new($stdout)
+
+class Author < ActiveRecord::Base
+  has_many :books
+
+  ## Optional: Meilisearch example
+  # include MeiliSearch::Rails
+  # extend Pagy::Meilisearch
+  #
+  # meilisearch do
+  #  attribute :name
+  # end
+end # :nodoc:
+
+class Book < ActiveRecord::Base
+  belongs_to :author
+
+  ## Optional: Meilisearch example
+  # include MeiliSearch::Rails
+  # extend Pagy::Meilisearch
+  # meilisearch do
+  #  attribute :name
+  # end
+end # :nodoc:
+
+1.upto(11) do |i|
+  Author.create(name: i)
+end
+
+Author.all.each_with_index do |author, i|
+  Book.create(author: author, name: i)
+end
+
+## Optional: Meilisearch example
+# Book.reindex!
 
 class TestController < ActionController::Base # :nodoc:
   include Rails.application.routes.url_helpers
-
   include Pagy::Backend
 
   def index
-    meta, _records = pagy(Record.none, items: 10)
-    render json: { data: [], meta: pagy_metadata(meta) }
+    meta, @books = pagy(Book.all, items: 10)
+
+    ## Optional: Meilisearch example
+    # books         = Book.includes(:author).pagy_search('*')
+    # @pagy, @books = pagy_meilisearch(books, items: 10)
+    # @books.each(&:author)
+
+    render json: { data: @books, meta: pagy_metadata(meta) }
   end
 
   ## override pagy methods if you need to here:
@@ -95,7 +152,8 @@ class TestControllerTest < ActionDispatch::IntegrationTest # :nodoc:
 
   test 'pagy json output - example' do
     get '/'
-    assert_equal response.parsed_body, { 'data' => [], 'meta' => { 'first_url' => '/?page=1', 'last_url' => '/?page=1' } }
+    assert_equal response.parsed_body, { 'data' => Book.first(10).as_json, 'meta' =>
+                                         { 'first_url' => '/?page=1', 'last_url' => '/?page=1' } }
   end
 
   def test_my_pagy_problem_here
@@ -109,18 +167,18 @@ class TestControllerTest < ActionDispatch::IntegrationTest # :nodoc:
   end
 end
 
-# or use rack to test:
-class BugTest < Minitest::Test # :nodoc:
-  include Rack::Test::Methods
-
-  def test_my_pagy_problem_again
-    get '/'
-    assert last_response.ok?
-  end
-
-  private
-
-  def app
-    Rails.application
-  end
-end
+## or use rack to test:
+# class BugTest < Minitest::Test # :nodoc:
+#   include Rack::Test::Methods
+#
+#   # def test_my_pagy_problem_again
+#   #  get '/'
+#   #  assert last_response.ok?
+#   # end
+#
+#   private
+#
+#   def app
+#     Rails.application
+#   end
+# end


### PR DESCRIPTION
### Why this PR?

* The use case seems to have developed from (https://github.com/ddnexus/pagy/pull/357)
and again in (https://github.com/ddnexus/pagy/issues/378). There seems to be a need to test with db, though it requires a dependency.

### What's changed?

* Add example for use with external services e.g. meilisearch. The
implementation might be better done with docker-compose? That use case
may present itself in future, however I am not able to do it at this second.

* Minor cleanup