### PR TITLE
fix ui bug - #381: input was disabled

### DIFF
--- a/lib/pagy/extras/bootstrap.rb
+++ b/lib/pagy/extras/bootstrap.rb
@@ -51,8 +51,8 @@ class Pagy # :nodoc:
       p_page  = pagy.page
       p_pages = pagy.pages
       input   = %(<input type="number" min="1" max="#{p_pages}" value="#{
-                    p_page}" class="text-primary" style="padding: 0; border: none; text-align: center; width: #{
-                    p_pages.to_s.length + 1}rem;">)
+                    p_page}" class="text-primary" style="pointer-events: auto; padding: 0; border: none; text-align: center;
+										width: #{p_pages.to_s.length + 1}rem;">)
 
       %(<nav#{p_id} class="pagy-bootstrap-combo-nav-js pagination" aria-label="pager"><div class="btn-group" role="group" #{
           pagy_data(pagy, :combo, pagy_marked_link(link))}>#{

--- a/test/pagy/extras/bootstrap_test.rb.rematch
+++ b/test/pagy/extras/bootstrap_test.rb.rematch
@@ -1,54 +1,47 @@
 ---
-"[1] pagy/extras/bootstrap::#pagy_bootstrap_combo_nav_js#test_0001_renders first page": '<nav
-  class="pagy-bootstrap-combo-nav-js pagination" aria-label="pager"><div class="btn-group"
-  role="group" data-pagy="WyJjb21ibyIsIjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICAgc3R5bGU9XCJkaXNwbGF5OiBub25lO1wiPjwvYT4iXQ=="><a
-  class="prev btn btn-primary disabled" href="#">&lsaquo;&nbsp;Prev</a><div class="pagy-combo-input
-  btn btn-primary disabled" style="white-space: nowrap;"><label>Page <input type="number"
-  min="1" max="6" value="1" class="text-primary" style="padding: 0; border: none;
-  text-align: center; width: 2rem;"> of 6</label></div><a href="/foo?page=2"   rel="next"
-  aria-label="next" class="next btn btn-primary">Next&nbsp;&rsaquo;</a></div></nav>'
-"[2] pagy/extras/bootstrap::#pagy_bootstrap_combo_nav_js#test_0001_renders first page": '<nav
-  id="test-nav-id" class="pagy-bootstrap-combo-nav-js pagination" aria-label="pager"><div
-  class="btn-group" role="group" data-pagy="WyJjb21ibyIsIjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICBsaW5rLWV4dHJhIHN0eWxlPVwiZGlzcGxheTogbm9uZTtcIj48L2E+Il0="><a
-  class="prev btn btn-primary disabled" href="#">&lsaquo;&nbsp;Prev</a><div class="pagy-combo-input
-  btn btn-primary disabled" style="white-space: nowrap;"><label>Page <input type="number"
-  min="1" max="6" value="1" class="text-primary" style="padding: 0; border: none;
-  text-align: center; width: 2rem;"> of 6</label></div><a href="/foo?page=2"  link-extra
-  rel="next" aria-label="next" class="next btn btn-primary">Next&nbsp;&rsaquo;</a></div></nav>'
-"[1] pagy/extras/bootstrap::#pagy_bootstrap_combo_nav_js#test_0003_renders last page": '<nav
-  class="pagy-bootstrap-combo-nav-js pagination" aria-label="pager"><div class="btn-group"
-  role="group" data-pagy="WyJjb21ibyIsIjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICAgc3R5bGU9XCJkaXNwbGF5OiBub25lO1wiPjwvYT4iXQ=="><a
-  href="/foo?page=5"   rel="prev" aria-label="previous" class="prev btn btn-primary">&lsaquo;&nbsp;Prev</a><div
-  class="pagy-combo-input btn btn-primary disabled" style="white-space: nowrap;"><label>Page
-  <input type="number" min="1" max="6" value="6" class="text-primary" style="padding:
-  0; border: none; text-align: center; width: 2rem;"> of 6</label></div><a class="next
-  btn btn-primary disabled" href="#">Next&nbsp;&rsaquo;</a></div></nav>'
-"[2] pagy/extras/bootstrap::#pagy_bootstrap_combo_nav_js#test_0003_renders last page": '<nav
-  id="test-nav-id" class="pagy-bootstrap-combo-nav-js pagination" aria-label="pager"><div
-  class="btn-group" role="group" data-pagy="WyJjb21ibyIsIjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICBsaW5rLWV4dHJhIHN0eWxlPVwiZGlzcGxheTogbm9uZTtcIj48L2E+Il0="><a
-  href="/foo?page=5"  link-extra rel="prev" aria-label="previous" class="prev btn
-  btn-primary">&lsaquo;&nbsp;Prev</a><div class="pagy-combo-input btn btn-primary
-  disabled" style="white-space: nowrap;"><label>Page <input type="number" min="1"
-  max="6" value="6" class="text-primary" style="padding: 0; border: none; text-align:
-  center; width: 2rem;"> of 6</label></div><a class="next btn btn-primary disabled"
-  href="#">Next&nbsp;&rsaquo;</a></div></nav>'
-"[1] pagy/extras/bootstrap::#pagy_bootstrap_combo_nav_js#test_0002_renders intermediate page": '<nav
-  class="pagy-bootstrap-combo-nav-js pagination" aria-label="pager"><div class="btn-group"
-  role="group" data-pagy="WyJjb21ibyIsIjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICAgc3R5bGU9XCJkaXNwbGF5OiBub25lO1wiPjwvYT4iXQ=="><a
-  href="/foo?page=2"   rel="prev" aria-label="previous" class="prev btn btn-primary">&lsaquo;&nbsp;Prev</a><div
-  class="pagy-combo-input btn btn-primary disabled" style="white-space: nowrap;"><label>Page
-  <input type="number" min="1" max="6" value="3" class="text-primary" style="padding:
-  0; border: none; text-align: center; width: 2rem;"> of 6</label></div><a href="/foo?page=4"   rel="next"
-  aria-label="next" class="next btn btn-primary">Next&nbsp;&rsaquo;</a></div></nav>'
-"[2] pagy/extras/bootstrap::#pagy_bootstrap_combo_nav_js#test_0002_renders intermediate page": '<nav
-  id="test-nav-id" class="pagy-bootstrap-combo-nav-js pagination" aria-label="pager"><div
-  class="btn-group" role="group" data-pagy="WyJjb21ibyIsIjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICBsaW5rLWV4dHJhIHN0eWxlPVwiZGlzcGxheTogbm9uZTtcIj48L2E+Il0="><a
-  href="/foo?page=2"  link-extra rel="prev" aria-label="previous" class="prev btn
-  btn-primary">&lsaquo;&nbsp;Prev</a><div class="pagy-combo-input btn btn-primary
-  disabled" style="white-space: nowrap;"><label>Page <input type="number" min="1"
-  max="6" value="3" class="text-primary" style="padding: 0; border: none; text-align:
-  center; width: 2rem;"> of 6</label></div><a href="/foo?page=4"  link-extra rel="next"
-  aria-label="next" class="next btn btn-primary">Next&nbsp;&rsaquo;</a></div></nav>'
+"[1] pagy/extras/bootstrap::#pagy_bootstrap_nav#test_0001_renders first page": <nav
+  class="pagy-bootstrap-nav" aria-label="pager"><ul class="pagination"><li class="page-item
+  prev disabled"><a href="#" class="page-link">&lsaquo;&nbsp;Prev</a></li><li class="page-item
+  active"><a href="/foo?page=1"  class="page-link"  >1</a></li><li class="page-item"><a
+  href="/foo?page=2"  class="page-link"  rel="next" >2</a></li><li class="page-item"><a
+  href="/foo?page=3"  class="page-link"  >3</a></li><li class="page-item"><a href="/foo?page=4"  class="page-link"  >4</a></li><li
+  class="page-item"><a href="/foo?page=5"  class="page-link"  >5</a></li><li class="page-item
+  gap disabled"><a href="#" class="page-link">&hellip;</a></li><li class="page-item"><a
+  href="/foo?page=50"  class="page-link"  >50</a></li><li class="page-item next"><a
+  href="/foo?page=2"  class="page-link"  rel="next" aria-label="next">Next&nbsp;&rsaquo;</a></li></ul></nav>
+"[2] pagy/extras/bootstrap::#pagy_bootstrap_nav#test_0001_renders first page": <nav
+  id="test-nav-id" class="pagy-bootstrap-nav" aria-label="pager"><ul class="pagination"><li
+  class="page-item prev disabled"><a href="#" class="page-link">&lsaquo;&nbsp;Prev</a></li><li
+  class="page-item active"><a href="/foo?page=1"  class="page-link" link-extra >1</a></li><li
+  class="page-item"><a href="/foo?page=2"  class="page-link" link-extra rel="next"
+  >2</a></li><li class="page-item"><a href="/foo?page=3"  class="page-link" link-extra
+  >3</a></li><li class="page-item"><a href="/foo?page=4"  class="page-link" link-extra
+  >4</a></li><li class="page-item"><a href="/foo?page=5"  class="page-link" link-extra
+  >5</a></li><li class="page-item gap disabled"><a href="#" class="page-link">&hellip;</a></li><li
+  class="page-item"><a href="/foo?page=50"  class="page-link" link-extra >50</a></li><li
+  class="page-item next"><a href="/foo?page=2"  class="page-link" link-extra rel="next"
+  aria-label="next">Next&nbsp;&rsaquo;</a></li></ul></nav>
+"[1] pagy/extras/bootstrap::#pagy_bootstrap_nav#test_0003_renders last page": <nav
+  class="pagy-bootstrap-nav" aria-label="pager"><ul class="pagination"><li class="page-item
+  prev"><a href="/foo?page=49"  class="page-link"  rel="prev" aria-label="previous">&lsaquo;&nbsp;Prev</a></li><li
+  class="page-item"><a href="/foo?page=1"  class="page-link"  >1</a></li><li class="page-item
+  gap disabled"><a href="#" class="page-link">&hellip;</a></li><li class="page-item"><a
+  href="/foo?page=46"  class="page-link"  >46</a></li><li class="page-item"><a href="/foo?page=47"  class="page-link"  >47</a></li><li
+  class="page-item"><a href="/foo?page=48"  class="page-link"  >48</a></li><li class="page-item"><a
+  href="/foo?page=49"  class="page-link"  rel="prev" >49</a></li><li class="page-item
+  active"><a href="/foo?page=50"  class="page-link"  >50</a></li><li class="page-item
+  next disabled"><a href="#" class="page-link">Next&nbsp;&rsaquo;</a></li></ul></nav>
+"[2] pagy/extras/bootstrap::#pagy_bootstrap_nav#test_0003_renders last page": <nav
+  id="test-nav-id" class="pagy-bootstrap-nav" aria-label="pager"><ul class="pagination"><li
+  class="page-item prev"><a href="/foo?page=49"  class="page-link" link-extra rel="prev"
+  aria-label="previous">&lsaquo;&nbsp;Prev</a></li><li class="page-item"><a href="/foo?page=1"  class="page-link"
+  link-extra >1</a></li><li class="page-item gap disabled"><a href="#" class="page-link">&hellip;</a></li><li
+  class="page-item"><a href="/foo?page=46"  class="page-link" link-extra >46</a></li><li
+  class="page-item"><a href="/foo?page=47"  class="page-link" link-extra >47</a></li><li
+  class="page-item"><a href="/foo?page=48"  class="page-link" link-extra >48</a></li><li
+  class="page-item"><a href="/foo?page=49"  class="page-link" link-extra rel="prev"
+  >49</a></li><li class="page-item active"><a href="/foo?page=50"  class="page-link"
+  link-extra >50</a></li><li class="page-item next disabled"><a href="#" class="page-link">Next&nbsp;&rsaquo;</a></li></ul></nav>
 "[1] pagy/extras/bootstrap::#pagy_bootstrap_nav#test_0002_renders intermediate page": <nav
   class="pagy-bootstrap-nav" aria-label="pager"><ul class="pagination"><li class="page-item
   prev"><a href="/foo?page=19"  class="page-link"  rel="prev" aria-label="previous">&lsaquo;&nbsp;Prev</a></li><li
@@ -82,53 +75,10 @@
   class="page-item"><a href="/foo?page=50"  class="page-link" link-extra >50</a></li><li
   class="page-item next"><a href="/foo?page=21"  class="page-link" link-extra rel="next"
   aria-label="next">Next&nbsp;&rsaquo;</a></li></ul></nav>
-"[1] pagy/extras/bootstrap::#pagy_bootstrap_nav#test_0003_renders last page": <nav
-  class="pagy-bootstrap-nav" aria-label="pager"><ul class="pagination"><li class="page-item
-  prev"><a href="/foo?page=49"  class="page-link"  rel="prev" aria-label="previous">&lsaquo;&nbsp;Prev</a></li><li
-  class="page-item"><a href="/foo?page=1"  class="page-link"  >1</a></li><li class="page-item
-  gap disabled"><a href="#" class="page-link">&hellip;</a></li><li class="page-item"><a
-  href="/foo?page=46"  class="page-link"  >46</a></li><li class="page-item"><a href="/foo?page=47"  class="page-link"  >47</a></li><li
-  class="page-item"><a href="/foo?page=48"  class="page-link"  >48</a></li><li class="page-item"><a
-  href="/foo?page=49"  class="page-link"  rel="prev" >49</a></li><li class="page-item
-  active"><a href="/foo?page=50"  class="page-link"  >50</a></li><li class="page-item
-  next disabled"><a href="#" class="page-link">Next&nbsp;&rsaquo;</a></li></ul></nav>
-"[2] pagy/extras/bootstrap::#pagy_bootstrap_nav#test_0003_renders last page": <nav
-  id="test-nav-id" class="pagy-bootstrap-nav" aria-label="pager"><ul class="pagination"><li
-  class="page-item prev"><a href="/foo?page=49"  class="page-link" link-extra rel="prev"
-  aria-label="previous">&lsaquo;&nbsp;Prev</a></li><li class="page-item"><a href="/foo?page=1"  class="page-link"
-  link-extra >1</a></li><li class="page-item gap disabled"><a href="#" class="page-link">&hellip;</a></li><li
-  class="page-item"><a href="/foo?page=46"  class="page-link" link-extra >46</a></li><li
-  class="page-item"><a href="/foo?page=47"  class="page-link" link-extra >47</a></li><li
-  class="page-item"><a href="/foo?page=48"  class="page-link" link-extra >48</a></li><li
-  class="page-item"><a href="/foo?page=49"  class="page-link" link-extra rel="prev"
-  >49</a></li><li class="page-item active"><a href="/foo?page=50"  class="page-link"
-  link-extra >50</a></li><li class="page-item next disabled"><a href="#" class="page-link">Next&nbsp;&rsaquo;</a></li></ul></nav>
-"[1] pagy/extras/bootstrap::#pagy_bootstrap_nav#test_0001_renders first page": <nav
-  class="pagy-bootstrap-nav" aria-label="pager"><ul class="pagination"><li class="page-item
-  prev disabled"><a href="#" class="page-link">&lsaquo;&nbsp;Prev</a></li><li class="page-item
-  active"><a href="/foo?page=1"  class="page-link"  >1</a></li><li class="page-item"><a
-  href="/foo?page=2"  class="page-link"  rel="next" >2</a></li><li class="page-item"><a
-  href="/foo?page=3"  class="page-link"  >3</a></li><li class="page-item"><a href="/foo?page=4"  class="page-link"  >4</a></li><li
-  class="page-item"><a href="/foo?page=5"  class="page-link"  >5</a></li><li class="page-item
-  gap disabled"><a href="#" class="page-link">&hellip;</a></li><li class="page-item"><a
-  href="/foo?page=50"  class="page-link"  >50</a></li><li class="page-item next"><a
-  href="/foo?page=2"  class="page-link"  rel="next" aria-label="next">Next&nbsp;&rsaquo;</a></li></ul></nav>
-"[2] pagy/extras/bootstrap::#pagy_bootstrap_nav#test_0001_renders first page": <nav
-  id="test-nav-id" class="pagy-bootstrap-nav" aria-label="pager"><ul class="pagination"><li
-  class="page-item prev disabled"><a href="#" class="page-link">&lsaquo;&nbsp;Prev</a></li><li
-  class="page-item active"><a href="/foo?page=1"  class="page-link" link-extra >1</a></li><li
-  class="page-item"><a href="/foo?page=2"  class="page-link" link-extra rel="next"
-  >2</a></li><li class="page-item"><a href="/foo?page=3"  class="page-link" link-extra
-  >3</a></li><li class="page-item"><a href="/foo?page=4"  class="page-link" link-extra
-  >4</a></li><li class="page-item"><a href="/foo?page=5"  class="page-link" link-extra
-  >5</a></li><li class="page-item gap disabled"><a href="#" class="page-link">&hellip;</a></li><li
-  class="page-item"><a href="/foo?page=50"  class="page-link" link-extra >50</a></li><li
-  class="page-item next"><a href="/foo?page=2"  class="page-link" link-extra rel="next"
-  aria-label="next">Next&nbsp;&rsaquo;</a></li></ul></nav>
-"[1] pagy/extras/bootstrap::#pagy_bootstrap_nav_js#test_0004_renders with :steps": <nav
-  class="pagy-rjs pagy-bootstrap-nav-js" aria-label="pager" data-pagy="WyJuYXYiLHsiYmVmb3JlIjoiPHVsIGNsYXNzPVwicGFnaW5hdGlvblwiPjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBwcmV2XCI+PGEgaHJlZj1cIi9mb28/cGFnZT0xOVwiICBjbGFzcz1cInBhZ2UtbGlua1wiICByZWw9XCJwcmV2XCIgYXJpYS1sYWJlbD1cInByZXZpb3VzXCI+JmxzYXF1bzsmbmJzcDtQcmV2PC9hPjwvbGk+IiwibGluayI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbVwiPjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICBjbGFzcz1cInBhZ2UtbGlua1wiICA+X19wYWd5X2xhYmVsX188L2E+PC9saT4iLCJhY3RpdmUiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW0gYWN0aXZlXCI+PGEgaHJlZj1cIi9mb28/cGFnZT1fX3BhZ3lfcGFnZV9fXCIgIGNsYXNzPVwicGFnZS1saW5rXCIgID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImdhcCI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBnYXAgZGlzYWJsZWRcIj48YSBocmVmPVwiI1wiIGNsYXNzPVwicGFnZS1saW5rXCI+JmhlbGxpcDs8L2E+PC9saT4iLCJhZnRlciI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBuZXh0XCI+PGEgaHJlZj1cIi9mb28/cGFnZT0yMVwiICBjbGFzcz1cInBhZ2UtbGlua1wiICByZWw9XCJuZXh0XCIgYXJpYS1sYWJlbD1cIm5leHRcIj5OZXh0Jm5ic3A7JnJzYXF1bzs8L2E+PC9saT48L3VsPiJ9LHsiMCI6WzEsImdhcCIsMTgsMTksIjIwIiwyMSwyMiwiZ2FwIiw1MF0sIjUwMCI6WzEsMiwiZ2FwIiwxNywxOCwxOSwiMjAiLDIxLDIyLDIzLCJnYXAiLDQ5LDUwXX0sbnVsbF0="></nav>
-"[2] pagy/extras/bootstrap::#pagy_bootstrap_nav_js#test_0004_renders with :steps": <nav
-  id="test-nav-id" class="pagy-rjs pagy-bootstrap-nav-js" aria-label="pager" data-pagy="WyJuYXYiLHsiYmVmb3JlIjoiPHVsIGNsYXNzPVwicGFnaW5hdGlvblwiPjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBwcmV2XCI+PGEgaHJlZj1cIi9mb28/cGFnZT0xOVwiICBjbGFzcz1cInBhZ2UtbGlua1wiIGxpbmstZXh0cmEgcmVsPVwicHJldlwiIGFyaWEtbGFiZWw9XCJwcmV2aW91c1wiPiZsc2FxdW87Jm5ic3A7UHJldjwvYT48L2xpPiIsImxpbmsiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW1cIj48YSBocmVmPVwiL2Zvbz9wYWdlPV9fcGFneV9wYWdlX19cIiAgY2xhc3M9XCJwYWdlLWxpbmtcIiBsaW5rLWV4dHJhID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImFjdGl2ZSI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBhY3RpdmVcIj48YSBocmVmPVwiL2Zvbz9wYWdlPV9fcGFneV9wYWdlX19cIiAgY2xhc3M9XCJwYWdlLWxpbmtcIiBsaW5rLWV4dHJhID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImdhcCI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBnYXAgZGlzYWJsZWRcIj48YSBocmVmPVwiI1wiIGNsYXNzPVwicGFnZS1saW5rXCI+JmhlbGxpcDs8L2E+PC9saT4iLCJhZnRlciI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBuZXh0XCI+PGEgaHJlZj1cIi9mb28/cGFnZT0yMVwiICBjbGFzcz1cInBhZ2UtbGlua1wiIGxpbmstZXh0cmEgcmVsPVwibmV4dFwiIGFyaWEtbGFiZWw9XCJuZXh0XCI+TmV4dCZuYnNwOyZyc2FxdW87PC9hPjwvbGk+PC91bD4ifSx7IjAiOlsxLCJnYXAiLDE4LDE5LCIyMCIsMjEsMjIsImdhcCIsNTBdLCI2MDAiOlsxLCJnYXAiLDE3LDE4LDE5LCIyMCIsMjEsMjIsMjMsImdhcCIsNTBdfSxudWxsXQ=="></nav>
+"[1] pagy/extras/bootstrap::#pagy_bootstrap_nav_js#test_0001_renders first page": <nav
+  class="pagy-bootstrap-nav-js" aria-label="pager" data-pagy="WyJuYXYiLHsiYmVmb3JlIjoiPHVsIGNsYXNzPVwicGFnaW5hdGlvblwiPjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBwcmV2IGRpc2FibGVkXCI+PGEgaHJlZj1cIiNcIiBjbGFzcz1cInBhZ2UtbGlua1wiPiZsc2FxdW87Jm5ic3A7UHJldjwvYT48L2xpPiIsImxpbmsiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW1cIj48YSBocmVmPVwiL2Zvbz9wYWdlPV9fcGFneV9wYWdlX19cIiAgY2xhc3M9XCJwYWdlLWxpbmtcIiAgPl9fcGFneV9sYWJlbF9fPC9hPjwvbGk+IiwiYWN0aXZlIjoiPGxpIGNsYXNzPVwicGFnZS1pdGVtIGFjdGl2ZVwiPjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICBjbGFzcz1cInBhZ2UtbGlua1wiICA+X19wYWd5X2xhYmVsX188L2E+PC9saT4iLCJnYXAiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW0gZ2FwIGRpc2FibGVkXCI+PGEgaHJlZj1cIiNcIiBjbGFzcz1cInBhZ2UtbGlua1wiPiZoZWxsaXA7PC9hPjwvbGk+IiwiYWZ0ZXIiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW0gbmV4dFwiPjxhIGhyZWY9XCIvZm9vP3BhZ2U9MlwiICBjbGFzcz1cInBhZ2UtbGlua1wiICByZWw9XCJuZXh0XCIgYXJpYS1sYWJlbD1cIm5leHRcIj5OZXh0Jm5ic3A7JnJzYXF1bzs8L2E+PC9saT48L3VsPiJ9LHsiMCI6WyIxIiwyLDMsNCw1LCJnYXAiLDUwXX0sbnVsbF0="></nav>
+"[2] pagy/extras/bootstrap::#pagy_bootstrap_nav_js#test_0001_renders first page": <nav
+  id="test-nav-id" class="pagy-rjs pagy-bootstrap-nav-js" aria-label="pager" data-pagy="WyJuYXYiLHsiYmVmb3JlIjoiPHVsIGNsYXNzPVwicGFnaW5hdGlvblwiPjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBwcmV2IGRpc2FibGVkXCI+PGEgaHJlZj1cIiNcIiBjbGFzcz1cInBhZ2UtbGlua1wiPiZsc2FxdW87Jm5ic3A7UHJldjwvYT48L2xpPiIsImxpbmsiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW1cIj48YSBocmVmPVwiL2Zvbz9wYWdlPV9fcGFneV9wYWdlX19cIiAgY2xhc3M9XCJwYWdlLWxpbmtcIiBsaW5rLWV4dHJhID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImFjdGl2ZSI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBhY3RpdmVcIj48YSBocmVmPVwiL2Zvbz9wYWdlPV9fcGFneV9wYWdlX19cIiAgY2xhc3M9XCJwYWdlLWxpbmtcIiBsaW5rLWV4dHJhID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImdhcCI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBnYXAgZGlzYWJsZWRcIj48YSBocmVmPVwiI1wiIGNsYXNzPVwicGFnZS1saW5rXCI+JmhlbGxpcDs8L2E+PC9saT4iLCJhZnRlciI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBuZXh0XCI+PGEgaHJlZj1cIi9mb28/cGFnZT0yXCIgIGNsYXNzPVwicGFnZS1saW5rXCIgbGluay1leHRyYSByZWw9XCJuZXh0XCIgYXJpYS1sYWJlbD1cIm5leHRcIj5OZXh0Jm5ic3A7JnJzYXF1bzs8L2E+PC9saT48L3VsPiJ9LHsiMCI6WyIxIiwyLDMsImdhcCIsNTBdLCI2MDAiOlsiMSIsMiwzLDQsImdhcCIsNTBdfSxudWxsXQ=="></nav>
 "[1] pagy/extras/bootstrap::#pagy_bootstrap_nav_js#test_0002_renders intermediate page": <nav
   class="pagy-bootstrap-nav-js" aria-label="pager" data-pagy="WyJuYXYiLHsiYmVmb3JlIjoiPHVsIGNsYXNzPVwicGFnaW5hdGlvblwiPjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBwcmV2XCI+PGEgaHJlZj1cIi9mb28/cGFnZT0xOVwiICBjbGFzcz1cInBhZ2UtbGlua1wiICByZWw9XCJwcmV2XCIgYXJpYS1sYWJlbD1cInByZXZpb3VzXCI+JmxzYXF1bzsmbmJzcDtQcmV2PC9hPjwvbGk+IiwibGluayI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbVwiPjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICBjbGFzcz1cInBhZ2UtbGlua1wiICA+X19wYWd5X2xhYmVsX188L2E+PC9saT4iLCJhY3RpdmUiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW0gYWN0aXZlXCI+PGEgaHJlZj1cIi9mb28/cGFnZT1fX3BhZ3lfcGFnZV9fXCIgIGNsYXNzPVwicGFnZS1saW5rXCIgID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImdhcCI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBnYXAgZGlzYWJsZWRcIj48YSBocmVmPVwiI1wiIGNsYXNzPVwicGFnZS1saW5rXCI+JmhlbGxpcDs8L2E+PC9saT4iLCJhZnRlciI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBuZXh0XCI+PGEgaHJlZj1cIi9mb28/cGFnZT0yMVwiICBjbGFzcz1cInBhZ2UtbGlua1wiICByZWw9XCJuZXh0XCIgYXJpYS1sYWJlbD1cIm5leHRcIj5OZXh0Jm5ic3A7JnJzYXF1bzs8L2E+PC9saT48L3VsPiJ9LHsiMCI6WzEsImdhcCIsMTYsMTcsMTgsMTksIjIwIiwyMSwyMiwyMywyNCwiZ2FwIiw1MF19LG51bGxd"></nav>
 "[2] pagy/extras/bootstrap::#pagy_bootstrap_nav_js#test_0002_renders intermediate page": <nav
@@ -137,7 +87,61 @@
   class="pagy-bootstrap-nav-js" aria-label="pager" data-pagy="WyJuYXYiLHsiYmVmb3JlIjoiPHVsIGNsYXNzPVwicGFnaW5hdGlvblwiPjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBwcmV2XCI+PGEgaHJlZj1cIi9mb28/cGFnZT00OVwiICBjbGFzcz1cInBhZ2UtbGlua1wiICByZWw9XCJwcmV2XCIgYXJpYS1sYWJlbD1cInByZXZpb3VzXCI+JmxzYXF1bzsmbmJzcDtQcmV2PC9hPjwvbGk+IiwibGluayI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbVwiPjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICBjbGFzcz1cInBhZ2UtbGlua1wiICA+X19wYWd5X2xhYmVsX188L2E+PC9saT4iLCJhY3RpdmUiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW0gYWN0aXZlXCI+PGEgaHJlZj1cIi9mb28/cGFnZT1fX3BhZ3lfcGFnZV9fXCIgIGNsYXNzPVwicGFnZS1saW5rXCIgID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImdhcCI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBnYXAgZGlzYWJsZWRcIj48YSBocmVmPVwiI1wiIGNsYXNzPVwicGFnZS1saW5rXCI+JmhlbGxpcDs8L2E+PC9saT4iLCJhZnRlciI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBuZXh0IGRpc2FibGVkXCI+PGEgaHJlZj1cIiNcIiBjbGFzcz1cInBhZ2UtbGlua1wiPk5leHQmbmJzcDsmcnNhcXVvOzwvYT48L2xpPjwvdWw+In0seyIwIjpbMSwiZ2FwIiw0Niw0Nyw0OCw0OSwiNTAiXX0sbnVsbF0="></nav>
 "[2] pagy/extras/bootstrap::#pagy_bootstrap_nav_js#test_0003_renders last page": <nav
   id="test-nav-id" class="pagy-rjs pagy-bootstrap-nav-js" aria-label="pager" data-pagy="WyJuYXYiLHsiYmVmb3JlIjoiPHVsIGNsYXNzPVwicGFnaW5hdGlvblwiPjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBwcmV2XCI+PGEgaHJlZj1cIi9mb28/cGFnZT00OVwiICBjbGFzcz1cInBhZ2UtbGlua1wiIGxpbmstZXh0cmEgcmVsPVwicHJldlwiIGFyaWEtbGFiZWw9XCJwcmV2aW91c1wiPiZsc2FxdW87Jm5ic3A7UHJldjwvYT48L2xpPiIsImxpbmsiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW1cIj48YSBocmVmPVwiL2Zvbz9wYWdlPV9fcGFneV9wYWdlX19cIiAgY2xhc3M9XCJwYWdlLWxpbmtcIiBsaW5rLWV4dHJhID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImFjdGl2ZSI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBhY3RpdmVcIj48YSBocmVmPVwiL2Zvbz9wYWdlPV9fcGFneV9wYWdlX19cIiAgY2xhc3M9XCJwYWdlLWxpbmtcIiBsaW5rLWV4dHJhID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImdhcCI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBnYXAgZGlzYWJsZWRcIj48YSBocmVmPVwiI1wiIGNsYXNzPVwicGFnZS1saW5rXCI+JmhlbGxpcDs8L2E+PC9saT4iLCJhZnRlciI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBuZXh0IGRpc2FibGVkXCI+PGEgaHJlZj1cIiNcIiBjbGFzcz1cInBhZ2UtbGlua1wiPk5leHQmbmJzcDsmcnNhcXVvOzwvYT48L2xpPjwvdWw+In0seyIwIjpbMSwiZ2FwIiw0OCw0OSwiNTAiXSwiNjAwIjpbMSwiZ2FwIiw0Nyw0OCw0OSwiNTAiXX0sbnVsbF0="></nav>
-"[1] pagy/extras/bootstrap::#pagy_bootstrap_nav_js#test_0001_renders first page": <nav
-  class="pagy-bootstrap-nav-js" aria-label="pager" data-pagy="WyJuYXYiLHsiYmVmb3JlIjoiPHVsIGNsYXNzPVwicGFnaW5hdGlvblwiPjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBwcmV2IGRpc2FibGVkXCI+PGEgaHJlZj1cIiNcIiBjbGFzcz1cInBhZ2UtbGlua1wiPiZsc2FxdW87Jm5ic3A7UHJldjwvYT48L2xpPiIsImxpbmsiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW1cIj48YSBocmVmPVwiL2Zvbz9wYWdlPV9fcGFneV9wYWdlX19cIiAgY2xhc3M9XCJwYWdlLWxpbmtcIiAgPl9fcGFneV9sYWJlbF9fPC9hPjwvbGk+IiwiYWN0aXZlIjoiPGxpIGNsYXNzPVwicGFnZS1pdGVtIGFjdGl2ZVwiPjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICBjbGFzcz1cInBhZ2UtbGlua1wiICA+X19wYWd5X2xhYmVsX188L2E+PC9saT4iLCJnYXAiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW0gZ2FwIGRpc2FibGVkXCI+PGEgaHJlZj1cIiNcIiBjbGFzcz1cInBhZ2UtbGlua1wiPiZoZWxsaXA7PC9hPjwvbGk+IiwiYWZ0ZXIiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW0gbmV4dFwiPjxhIGhyZWY9XCIvZm9vP3BhZ2U9MlwiICBjbGFzcz1cInBhZ2UtbGlua1wiICByZWw9XCJuZXh0XCIgYXJpYS1sYWJlbD1cIm5leHRcIj5OZXh0Jm5ic3A7JnJzYXF1bzs8L2E+PC9saT48L3VsPiJ9LHsiMCI6WyIxIiwyLDMsNCw1LCJnYXAiLDUwXX0sbnVsbF0="></nav>
-"[2] pagy/extras/bootstrap::#pagy_bootstrap_nav_js#test_0001_renders first page": <nav
-  id="test-nav-id" class="pagy-rjs pagy-bootstrap-nav-js" aria-label="pager" data-pagy="WyJuYXYiLHsiYmVmb3JlIjoiPHVsIGNsYXNzPVwicGFnaW5hdGlvblwiPjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBwcmV2IGRpc2FibGVkXCI+PGEgaHJlZj1cIiNcIiBjbGFzcz1cInBhZ2UtbGlua1wiPiZsc2FxdW87Jm5ic3A7UHJldjwvYT48L2xpPiIsImxpbmsiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW1cIj48YSBocmVmPVwiL2Zvbz9wYWdlPV9fcGFneV9wYWdlX19cIiAgY2xhc3M9XCJwYWdlLWxpbmtcIiBsaW5rLWV4dHJhID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImFjdGl2ZSI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBhY3RpdmVcIj48YSBocmVmPVwiL2Zvbz9wYWdlPV9fcGFneV9wYWdlX19cIiAgY2xhc3M9XCJwYWdlLWxpbmtcIiBsaW5rLWV4dHJhID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImdhcCI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBnYXAgZGlzYWJsZWRcIj48YSBocmVmPVwiI1wiIGNsYXNzPVwicGFnZS1saW5rXCI+JmhlbGxpcDs8L2E+PC9saT4iLCJhZnRlciI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBuZXh0XCI+PGEgaHJlZj1cIi9mb28/cGFnZT0yXCIgIGNsYXNzPVwicGFnZS1saW5rXCIgbGluay1leHRyYSByZWw9XCJuZXh0XCIgYXJpYS1sYWJlbD1cIm5leHRcIj5OZXh0Jm5ic3A7JnJzYXF1bzs8L2E+PC9saT48L3VsPiJ9LHsiMCI6WyIxIiwyLDMsImdhcCIsNTBdLCI2MDAiOlsiMSIsMiwzLDQsImdhcCIsNTBdfSxudWxsXQ=="></nav>
+"[1] pagy/extras/bootstrap::#pagy_bootstrap_nav_js#test_0004_renders with :steps": <nav
+  class="pagy-rjs pagy-bootstrap-nav-js" aria-label="pager" data-pagy="WyJuYXYiLHsiYmVmb3JlIjoiPHVsIGNsYXNzPVwicGFnaW5hdGlvblwiPjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBwcmV2XCI+PGEgaHJlZj1cIi9mb28/cGFnZT0xOVwiICBjbGFzcz1cInBhZ2UtbGlua1wiICByZWw9XCJwcmV2XCIgYXJpYS1sYWJlbD1cInByZXZpb3VzXCI+JmxzYXF1bzsmbmJzcDtQcmV2PC9hPjwvbGk+IiwibGluayI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbVwiPjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICBjbGFzcz1cInBhZ2UtbGlua1wiICA+X19wYWd5X2xhYmVsX188L2E+PC9saT4iLCJhY3RpdmUiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW0gYWN0aXZlXCI+PGEgaHJlZj1cIi9mb28/cGFnZT1fX3BhZ3lfcGFnZV9fXCIgIGNsYXNzPVwicGFnZS1saW5rXCIgID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImdhcCI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBnYXAgZGlzYWJsZWRcIj48YSBocmVmPVwiI1wiIGNsYXNzPVwicGFnZS1saW5rXCI+JmhlbGxpcDs8L2E+PC9saT4iLCJhZnRlciI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBuZXh0XCI+PGEgaHJlZj1cIi9mb28/cGFnZT0yMVwiICBjbGFzcz1cInBhZ2UtbGlua1wiICByZWw9XCJuZXh0XCIgYXJpYS1sYWJlbD1cIm5leHRcIj5OZXh0Jm5ic3A7JnJzYXF1bzs8L2E+PC9saT48L3VsPiJ9LHsiMCI6WzEsImdhcCIsMTgsMTksIjIwIiwyMSwyMiwiZ2FwIiw1MF0sIjUwMCI6WzEsMiwiZ2FwIiwxNywxOCwxOSwiMjAiLDIxLDIyLDIzLCJnYXAiLDQ5LDUwXX0sbnVsbF0="></nav>
+"[2] pagy/extras/bootstrap::#pagy_bootstrap_nav_js#test_0004_renders with :steps": <nav
+  id="test-nav-id" class="pagy-rjs pagy-bootstrap-nav-js" aria-label="pager" data-pagy="WyJuYXYiLHsiYmVmb3JlIjoiPHVsIGNsYXNzPVwicGFnaW5hdGlvblwiPjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBwcmV2XCI+PGEgaHJlZj1cIi9mb28/cGFnZT0xOVwiICBjbGFzcz1cInBhZ2UtbGlua1wiIGxpbmstZXh0cmEgcmVsPVwicHJldlwiIGFyaWEtbGFiZWw9XCJwcmV2aW91c1wiPiZsc2FxdW87Jm5ic3A7UHJldjwvYT48L2xpPiIsImxpbmsiOiI8bGkgY2xhc3M9XCJwYWdlLWl0ZW1cIj48YSBocmVmPVwiL2Zvbz9wYWdlPV9fcGFneV9wYWdlX19cIiAgY2xhc3M9XCJwYWdlLWxpbmtcIiBsaW5rLWV4dHJhID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImFjdGl2ZSI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBhY3RpdmVcIj48YSBocmVmPVwiL2Zvbz9wYWdlPV9fcGFneV9wYWdlX19cIiAgY2xhc3M9XCJwYWdlLWxpbmtcIiBsaW5rLWV4dHJhID5fX3BhZ3lfbGFiZWxfXzwvYT48L2xpPiIsImdhcCI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBnYXAgZGlzYWJsZWRcIj48YSBocmVmPVwiI1wiIGNsYXNzPVwicGFnZS1saW5rXCI+JmhlbGxpcDs8L2E+PC9saT4iLCJhZnRlciI6IjxsaSBjbGFzcz1cInBhZ2UtaXRlbSBuZXh0XCI+PGEgaHJlZj1cIi9mb28/cGFnZT0yMVwiICBjbGFzcz1cInBhZ2UtbGlua1wiIGxpbmstZXh0cmEgcmVsPVwibmV4dFwiIGFyaWEtbGFiZWw9XCJuZXh0XCI+TmV4dCZuYnNwOyZyc2FxdW87PC9hPjwvbGk+PC91bD4ifSx7IjAiOlsxLCJnYXAiLDE4LDE5LCIyMCIsMjEsMjIsImdhcCIsNTBdLCI2MDAiOlsxLCJnYXAiLDE3LDE4LDE5LCIyMCIsMjEsMjIsMjMsImdhcCIsNTBdfSxudWxsXQ=="></nav>
+"[1] pagy/extras/bootstrap::#pagy_bootstrap_combo_nav_js#test_0003_renders last page": "<nav
+  class=\"pagy-bootstrap-combo-nav-js pagination\" aria-label=\"pager\"><div class=\"btn-group\"
+  role=\"group\" data-pagy=\"WyJjb21ibyIsIjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICAgc3R5bGU9XCJkaXNwbGF5OiBub25lO1wiPjwvYT4iXQ==\"><a
+  href=\"/foo?page=5\"   rel=\"prev\" aria-label=\"previous\" class=\"prev btn btn-primary\">&lsaquo;&nbsp;Prev</a><div
+  class=\"pagy-combo-input btn btn-primary disabled\" style=\"white-space: nowrap;\"><label>Page
+  <input type=\"number\" min=\"1\" max=\"6\" value=\"6\" class=\"text-primary\" style=\"pointer-events:
+  auto; padding: 0; border: none; text-align: center;\n\t\t\t\t\t\t\t\t\t\twidth:
+  2rem;\"> of 6</label></div><a class=\"next btn btn-primary disabled\" href=\"#\">Next&nbsp;&rsaquo;</a></div></nav>"
+"[2] pagy/extras/bootstrap::#pagy_bootstrap_combo_nav_js#test_0003_renders last page": "<nav
+  id=\"test-nav-id\" class=\"pagy-bootstrap-combo-nav-js pagination\" aria-label=\"pager\"><div
+  class=\"btn-group\" role=\"group\" data-pagy=\"WyJjb21ibyIsIjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICBsaW5rLWV4dHJhIHN0eWxlPVwiZGlzcGxheTogbm9uZTtcIj48L2E+Il0=\"><a
+  href=\"/foo?page=5\"  link-extra rel=\"prev\" aria-label=\"previous\" class=\"prev
+  btn btn-primary\">&lsaquo;&nbsp;Prev</a><div class=\"pagy-combo-input btn btn-primary
+  disabled\" style=\"white-space: nowrap;\"><label>Page <input type=\"number\" min=\"1\"
+  max=\"6\" value=\"6\" class=\"text-primary\" style=\"pointer-events: auto; padding:
+  0; border: none; text-align: center;\n\t\t\t\t\t\t\t\t\t\twidth: 2rem;\"> of 6</label></div><a
+  class=\"next btn btn-primary disabled\" href=\"#\">Next&nbsp;&rsaquo;</a></div></nav>"
+"[1] pagy/extras/bootstrap::#pagy_bootstrap_combo_nav_js#test_0001_renders first page": "<nav
+  class=\"pagy-bootstrap-combo-nav-js pagination\" aria-label=\"pager\"><div class=\"btn-group\"
+  role=\"group\" data-pagy=\"WyJjb21ibyIsIjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICAgc3R5bGU9XCJkaXNwbGF5OiBub25lO1wiPjwvYT4iXQ==\"><a
+  class=\"prev btn btn-primary disabled\" href=\"#\">&lsaquo;&nbsp;Prev</a><div class=\"pagy-combo-input
+  btn btn-primary disabled\" style=\"white-space: nowrap;\"><label>Page <input type=\"number\"
+  min=\"1\" max=\"6\" value=\"1\" class=\"text-primary\" style=\"pointer-events: auto;
+  padding: 0; border: none; text-align: center;\n\t\t\t\t\t\t\t\t\t\twidth: 2rem;\">
+  of 6</label></div><a href=\"/foo?page=2\"   rel=\"next\" aria-label=\"next\" class=\"next
+  btn btn-primary\">Next&nbsp;&rsaquo;</a></div></nav>"
+"[2] pagy/extras/bootstrap::#pagy_bootstrap_combo_nav_js#test_0001_renders first page": "<nav
+  id=\"test-nav-id\" class=\"pagy-bootstrap-combo-nav-js pagination\" aria-label=\"pager\"><div
+  class=\"btn-group\" role=\"group\" data-pagy=\"WyJjb21ibyIsIjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICBsaW5rLWV4dHJhIHN0eWxlPVwiZGlzcGxheTogbm9uZTtcIj48L2E+Il0=\"><a
+  class=\"prev btn btn-primary disabled\" href=\"#\">&lsaquo;&nbsp;Prev</a><div class=\"pagy-combo-input
+  btn btn-primary disabled\" style=\"white-space: nowrap;\"><label>Page <input type=\"number\"
+  min=\"1\" max=\"6\" value=\"1\" class=\"text-primary\" style=\"pointer-events: auto;
+  padding: 0; border: none; text-align: center;\n\t\t\t\t\t\t\t\t\t\twidth: 2rem;\">
+  of 6</label></div><a href=\"/foo?page=2\"  link-extra rel=\"next\" aria-label=\"next\"
+  class=\"next btn btn-primary\">Next&nbsp;&rsaquo;</a></div></nav>"
+"[1] pagy/extras/bootstrap::#pagy_bootstrap_combo_nav_js#test_0002_renders intermediate page": "<nav
+  class=\"pagy-bootstrap-combo-nav-js pagination\" aria-label=\"pager\"><div class=\"btn-group\"
+  role=\"group\" data-pagy=\"WyJjb21ibyIsIjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICAgc3R5bGU9XCJkaXNwbGF5OiBub25lO1wiPjwvYT4iXQ==\"><a
+  href=\"/foo?page=2\"   rel=\"prev\" aria-label=\"previous\" class=\"prev btn btn-primary\">&lsaquo;&nbsp;Prev</a><div
+  class=\"pagy-combo-input btn btn-primary disabled\" style=\"white-space: nowrap;\"><label>Page
+  <input type=\"number\" min=\"1\" max=\"6\" value=\"3\" class=\"text-primary\" style=\"pointer-events:
+  auto; padding: 0; border: none; text-align: center;\n\t\t\t\t\t\t\t\t\t\twidth:
+  2rem;\"> of 6</label></div><a href=\"/foo?page=4\"   rel=\"next\" aria-label=\"next\"
+  class=\"next btn btn-primary\">Next&nbsp;&rsaquo;</a></div></nav>"
+"[2] pagy/extras/bootstrap::#pagy_bootstrap_combo_nav_js#test_0002_renders intermediate page": "<nav
+  id=\"test-nav-id\" class=\"pagy-bootstrap-combo-nav-js pagination\" aria-label=\"pager\"><div
+  class=\"btn-group\" role=\"group\" data-pagy=\"WyJjb21ibyIsIjxhIGhyZWY9XCIvZm9vP3BhZ2U9X19wYWd5X3BhZ2VfX1wiICBsaW5rLWV4dHJhIHN0eWxlPVwiZGlzcGxheTogbm9uZTtcIj48L2E+Il0=\"><a
+  href=\"/foo?page=2\"  link-extra rel=\"prev\" aria-label=\"previous\" class=\"prev
+  btn btn-primary\">&lsaquo;&nbsp;Prev</a><div class=\"pagy-combo-input btn btn-primary
+  disabled\" style=\"white-space: nowrap;\"><label>Page <input type=\"number\" min=\"1\"
+  max=\"6\" value=\"3\" class=\"text-primary\" style=\"pointer-events: auto; padding:
+  0; border: none; text-align: center;\n\t\t\t\t\t\t\t\t\t\twidth: 2rem;\"> of 6</label></div><a
+  href=\"/foo?page=4\"  link-extra rel=\"next\" aria-label=\"next\" class=\"next btn
+  btn-primary\">Next&nbsp;&rsaquo;</a></div></nav>"


### PR DESCRIPTION
### What is this?
Fix for https://github.com/ddnexus/pagy/issues/381

### What was done?
Previously when using the combo box, you weren't able to select the input and type in the page you want to go to.

#### Why not?

- We had a parent element which had the 'disabled' class applied to it. This rendered descended child elements also disabled. But we don't want them disabled: we want to allow people to type in page numbers when they want to. Using in-line styles, we have basically overriden the 'disabled' input by allow pointer access to apply, as per normal, to the input element.
- I have not checked for WAI-ARIA compliance. It probably isn't complaint.

(This solution doesn't touch the styling of bootstrap, though I have checked three main versions of bootstrap against this solution. And it seems to work as before.)

Hope this helps.