### PR TITLE
Fix NoMethodError when page param is a hash

### DIFF
--- a/lib/pagy.rb
+++ b/lib/pagy.rb
@@ -92,7 +92,7 @@ class Pagy
   def setup_vars(name_min)
     name_min.each do |name, min|
       raise VariableError.new(self, name, ">= #{min}", @vars[name]) \
-            unless @vars[name] && instance_variable_set(:"@#{name}", @vars[name].to_i) >= min
+            unless @vars[name]&.respond_to?(:to_i) && instance_variable_set(:"@#{name}", @vars[name].to_i) >= min
     end
   end
 

--- a/test/pagy/exceptions_test.rb
+++ b/test/pagy/exceptions_test.rb
@@ -26,6 +26,13 @@ describe 'pagy/exceptions' do
         _(e.variable).must_equal :page
         _(e.value).must_equal 'string'
       end
+
+      begin
+        Pagy.new(count: 1, page: {})
+      rescue Pagy::VariableError => e
+        _(e.variable).must_equal :page
+        _(e.value).must_equal({})
+      end
     end
 
     it 'raises for other variables' do

--- a/test/pagy_test.rb
+++ b/test/pagy_test.rb
@@ -53,6 +53,7 @@ describe 'pagy' do
       _ { Pagy.new({}) }.must_raise Pagy::VariableError
       _ { Pagy.new(count: 0, page: -1) }.must_raise Pagy::VariableError
       _ { Pagy.new(count: 100, page: 0) }.must_raise Pagy::VariableError
+      _ { Pagy.new(count: 100, page: {}) }.must_raise Pagy::VariableError
       _ { Pagy.new(count: 100, page: 2, items: 0) }.must_raise Pagy::VariableError
       _ { Pagy.new(count: 100, page: 2, size: [1, 2, 3]).series }.must_raise Pagy::VariableError
       _ { Pagy.new(count: 100, page: 2, size: [1, 2, 3, '4']).series }.must_raise Pagy::VariableError


### PR DESCRIPTION
`NoMethodError` is raised when the `page` param is a hash, e.g., `page[something]=1`. This can be caused by bots that are trying to find vulnerabilities by manipulating the params.

### Steps to replicate
Run the self-contained Sinatra/Rails app.
Set the `page` param to a hash, e.g., http://localhost:8080/?page[something]=1

#### Expected
`Pagy::VariableError` is raised.

#### Actual
`NoMethodError` is raised: `undefined method 'to_i' for {"something"=>"1"}`.