### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,11 @@ Style/CommentedKeyword:
 Style/EmptyCaseCondition:
   Enabled: false
 
+# cannot inline the disabling in the file because rubocop complains anyway
+Style/RedundantInitialize:
+  Exclude:
+    - test/mock_helpers/arel.rb
+
 # these cops are disabled only in the test files in order to
 # allow to copy and paste the failed output for test reconciliation
 Style/StringLiterals:

--- a/test/mock_helpers/arel.rb
+++ b/test/mock_helpers/arel.rb
@@ -15,9 +15,7 @@ module Arel
 
   module Nodes
     class Grouping
-      def initialize(_)
-        puts ""     # rubocop bug!
-      end
+      def initialize(_); end
     end
   end
 end


### PR DESCRIPTION
As the checkout action in the configuration is out of date, Dependabot should open a PR to update the action after this is merged.