### PR TITLE
Fix for #394 - updated pagy/lib/pagy/extras/meilisearch.rb

### DIFF
--- a/lib/pagy/extras/meilisearch.rb
+++ b/lib/pagy/extras/meilisearch.rb
@@ -29,7 +29,7 @@ class Pagy # :nodoc:
       def new_from_meilisearch(results, vars = {})
         vars[:items] = results.raw_answer['limit']
         vars[:page]  = (results.raw_answer['offset'] / vars[:items]) + 1
-        vars[:count] = results.raw_answer['estimatedTotalHits']
+        vars[:count] = results.raw_answer.dig('estimatedTotalHits') || results.raw_answer.dig('nbHits')
         new(vars)
       end
     end
@@ -45,7 +45,7 @@ class Pagy # :nodoc:
         options[:limit]      = vars[:items]
         options[:offset]     = (vars[:page] - 1) * vars[:items]
         results              = model.send(DEFAULT[:meilisearch_search], term, **options)
-        vars[:count]         = results.raw_answer['estimatedTotalHits']
+        vars[:count]         = results.raw_answer.dig('estimatedTotalHits') || results.raw_answer.dig('nbHits')
         pagy                 = ::Pagy.new(vars)
         # with :last_page overflow we need to re-run the method in order to get the hits
         return pagy_meilisearch(pagy_search_args, vars.merge(page: pagy.page)) \

--- a/lib/pagy/extras/meilisearch.rb
+++ b/lib/pagy/extras/meilisearch.rb
@@ -29,7 +29,7 @@ class Pagy # :nodoc:
       def new_from_meilisearch(results, vars = {})
         vars[:items] = results.raw_answer['limit']
         vars[:page]  = (results.raw_answer['offset'] / vars[:items]) + 1
-        vars[:count] = results.raw_answer['nbHits']
+        vars[:count] = results.raw_answer['estimatedTotalHits']
         new(vars)
       end
     end
@@ -45,7 +45,7 @@ class Pagy # :nodoc:
         options[:limit]      = vars[:items]
         options[:offset]     = (vars[:page] - 1) * vars[:items]
         results              = model.send(DEFAULT[:meilisearch_search], term, **options)
-        vars[:count]         = results.raw_answer['nbHits']
+        vars[:count]         = results.raw_answer['estimatedTotalHits']
         pagy                 = ::Pagy.new(vars)
         # with :last_page overflow we need to re-run the method in order to get the hits
         return pagy_meilisearch(pagy_search_args, vars.merge(page: pagy.page)) \


### PR DESCRIPTION
### What is this?
Fix for https://github.com/ddnexus/pagy/issues/394

### What was done?
nbHits renamed to estimatedTotalHits

[Meilisearch 0.28.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0) has introduced breaking changes: Changes in /indexes/{uid}/search endpoint - nbHits is renamed estimatedTotalHits. Some users were confused by the old name and used it for their pagination, which we discourage. Please check out this [fresh new guide](https://docs.meilisearch.com/learn/advanced/pagination.html) to learn how to paginate with Meilisearch without using nbHits.