### PR TITLE
Fixed small typo in German

### DIFF
--- a/lib/locales/de.yml
+++ b/lib/locales/de.yml
@@ -13,7 +13,7 @@ de:
       gap: "&hellip;"
 
     info:
-      no_items: "Kein %{item_name} gefunden"
+      no_items: "Keine %{item_name} gefunden"
       single_page: "Zeige <b>%{count}</b> %{item_name}"
       multiple_pages: "Zeige %{item_name} <b>%{from}-%{to}</b> von <b>%{count}</b> gesamt"
 


### PR DESCRIPTION
For Completeness:

* singular: "Kein Eintrag"
* plural: "Keine Einträge"

Corrects from (incorrect):
> Kein Einträge gefunden

To new:
> Keine Einträge gefunden