### PR TITLE
Update korean translation

### DIFF
--- a/lib/locales/ko.yml
+++ b/lib/locales/ko.yml
@@ -7,7 +7,7 @@ ko:
 
     nav:
       prev: "&lsaquo;&nbsp;이전"
-      next: "이후&nbsp;&rsaquo;"
+      next: "다음&nbsp;&rsaquo;"
       gap: "&hellip;"
 
     info:


### PR DESCRIPTION
In Korean, "다음" is more natural translation for "Next".
Google also uses "다음" for pagination.

![image](https://user-images.githubusercontent.com/65494027/205109484-e00ffbb0-cbf1-414f-a865-a47d358235a6.png)
