### PR TITLE
Add Meilisearch finite pagination by default in the meilisearch extra

### DIFF
--- a/docs/extras/meilisearch.md
+++ b/docs/extras/meilisearch.md
@@ -20,7 +20,7 @@ require 'pagy/extras/meilisearch'
 If you have an already paginated `Meilisearch` results, you can get the `Pagy` object out of it:
 
 ```ruby
-@results = Model.ms_search(nil, offset: 10, limit: 10, ...)
+@results = Model.ms_search(nil, hits_per_page: 10, page: 10, ...)
 @pagy    = Pagy.new_from_meilisearch(@results, ...)
 ```
 
@@ -46,14 +46,14 @@ results         = Article.pagy_search(params[:q])
 
 - [meilisearch.rb](https://github.com/ddnexus/pagy/blob/master/lib/pagy/extras/meilisearch.rb)
 
-## Pasive mode
+## Passive mode
 
 ### Pagy.new_from_meilisearch
 
 This constructor accepts a Meilisearch as the first argument, plus the usual optional variable hash. It sets the `:items`, `:page` and `:count` pagy variables extracted/calculated out of the Meilisearch object.
 
 ```ruby
-@results = Model.ms_search(nil, offset: 10, limit: 10, ...)
+@results = Model.ms_search(nil, hits_per_page: 10, page: 5, ...)
 @pagy    = Pagy.new_from_meilisearch(@results, ...)
 ```
 
@@ -73,7 +73,7 @@ The `Pagy::Meilisearch` adds the `pagy_search` class method that you must use in
 
 ### pagy_search(...)
 
-This method accepts the same arguments of the `search` method and you must use it in its place. This extra uses it in order to capture the arguments, automatically merging the calculated `:offset` and `:limit` options before passing them to the standard `search` method internally.
+This method accepts the same arguments of the `search` method and you must use it in its place.
 
 ### Variables
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,6 +2,7 @@
     "name": "pagy.e2e",
     "description": "Pagy E2E Testing",
     "private": true,
+    "type": "module",
     "engines": {
         "node": ">=16.15.0"
     },

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -2,7 +2,8 @@
     "include": ["./cypress/**/*.ts"],
     "compilerOptions": {
         "strict": true,
-        "target": "es5",
+        "target": "es2016",
+        "module": "ES6",
         "lib": ["esnext", "dom", "dom.iterable"],
         "types": ["cypress", "node"],
         "noEmit": true,

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -13,5 +13,9 @@
         "allowSyntheticDefaultImports": true,
         "moduleResolution": "node",
         "resolveJsonModule": true
+    },
+    "ts-node": {
+        // Tell ts-node CLI to install the --loader automatically
+        "esm": true
     }
 }

--- a/lib/pagy/extras/meilisearch.rb
+++ b/lib/pagy/extras/meilisearch.rb
@@ -19,9 +19,10 @@ class Pagy # :nodoc:
     module Pagy
       # Create a Pagy object from a Meilisearch results
       def new_from_meilisearch(results, vars = {})
-        vars[:items] = results.raw_answer['limit']
-        vars[:page]  = (results.raw_answer['offset'] / vars[:items]) + 1
-        vars[:count] = results.raw_answer['nbHits']
+        vars[:items] = results.raw_answer['hitsPerPage']
+        vars[:page]  = results.raw_answer['page']
+        vars[:count] = results.raw_answer['totalHits']
+
         new(vars)
       end
     end
@@ -32,13 +33,14 @@ class Pagy # :nodoc:
 
       # Return Pagy object and results
       def pagy_meilisearch(pagy_search_args, vars = {})
-        model, term, options = pagy_search_args
-        vars                 = pagy_meilisearch_get_vars(nil, vars)
-        options[:limit]      = vars[:items]
-        options[:offset]     = (vars[:page] - 1) * vars[:items]
-        results              = model.send(DEFAULT[:meilisearch_search], term, **options)
-        vars[:count]         = results.raw_answer['nbHits']
-        pagy                 = ::Pagy.new(vars)
+        model, term, options    = pagy_search_args
+        vars                    = pagy_meilisearch_get_vars(nil, vars)
+        options[:hits_per_page] = vars[:items]
+        options[:page]          = vars[:page]
+        results                 = model.send(:ms_search, term, **options)
+        vars[:count]            = results.raw_answer['totalHits']
+
+        pagy                    = ::Pagy.new(vars)
         # with :last_page overflow we need to re-run the method in order to get the hits
         return pagy_meilisearch(pagy_search_args, vars.merge(page: pagy.page)) \
                if defined?(::Pagy::OverflowExtra) && pagy.overflow? && pagy.vars[:overflow] == :last_page

--- a/test/mock_helpers/meilisearch.rb
+++ b/test/mock_helpers/meilisearch.rb
@@ -9,16 +9,17 @@ module MockMeilisearch
   class Results < Array
     def initialize(query, params = {})
       @query = query
-      @params = { offset: 0, limit: 10 }.merge(params)
-      super RESULTS[@query].slice(@params[:offset], @params[:limit]) || []
+      @params = { page: 1, hits_per_page: 10 }.merge(params)
+
+      super RESULTS[@query].slice(@params[:hits_per_page] * (@params[:page] - 1), @params[:hits_per_page]) || []
     end
 
     def raw_answer
       {
-        'hits'   => self,
-        'offset' => @params[:offset],
-        'limit'  => @params[:limit],
-        'nbHits' => RESULTS[@query].length
+        'hits'        => self,
+        'hitsPerPage' => @params[:hits_per_page],
+        'page'        => @params[:page],
+        'totalHits'   => RESULTS[@query].length
       }
     end
   end

--- a/test/pagy/extras/meilisearch_test.rb
+++ b/test/pagy/extras/meilisearch_test.rb
@@ -94,7 +94,7 @@ describe 'pagy/extras/meilisearch' do
         _(pagy.page).must_equal 1
       end
       it 'paginates results with vars' do
-        results = MockMeilisearch::Model.ms_search('b', limit: 15, offset: 30)
+        results = MockMeilisearch::Model.ms_search('b', hits_per_page: 15, page: 3)
         pagy    = Pagy.new_from_meilisearch(results, link_extra: 'X')
         _(pagy).must_be_instance_of Pagy
         _(pagy.count).must_equal 1000


### PR DESCRIPTION
Hi @ddnexus, this is the implementation to v6, which will support the finite pagination of Meilisearch out of the box.

The `limit` and `offset` params should no longer be used in this context, so this will be the most significant breaking change.

- [x] Try out with a rails app.