### PR TITLE
docs: simplify introduction

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,42 +6,41 @@ icon: home
 
 ## Pagination is a simple task
 
-A classic pagination gem needs to calculate a series of 10-20 sequential integers (the page numbers) and loop through that series to produce one link per integer. That's just a long string with a few numbers in it, and it's a very simple task... unless someone builds a whole complex world of thousands of objects around a simple series of integers :).
+A pagination gem needs to calculate 10-20 sequential integers (the page numbers) and loop through them to produce one page link per integer - that's just a long string with a few numbers in it. 
 
-## Pagy keeps it simple
+It's a simple task, that ought to be done simply:
 
-Pagy keeps pagination as straightforward as it could be: there are no "declarative DSL" to learn, no "global pollution" to avoid, no need for any special module or adapter. There are no nested modules, classes nor countless methods and many hundreds lines of code... all really difficult to justify for such a simple task.
+## Pagy's Simplicity
 
-Pagy is simple. Just take a look at the core source: [pagy.rb](https://github.com/ddnexus/pagy/blob/master/lib/pagy.rb), [pagy/backend.rb](https://github.com/ddnexus/pagy/blob/master/lib/pagy/backend.rb), [pagy/frontend.rb](https://github.com/ddnexus/pagy/blob/master/lib/pagy/frontend.rb) .
+* no declarative DSLs, 
+* no "global pollution", 
+* no need for special modules / adapters, 
+* no nested modules, classes nor countless methods
+* no hard dependency on Rails - no engine required.
 
- Its size and simplicity is one of the reasons of its stunning performance.
+## Advantages - Pagy:
 
-## Specialized code instead of generic helpers
+* is barely a lick over 100 lines of code,  and is readily comprehensive - checkout out the core: [pagy.rb](https://github.com/ddnexus/pagy/blob/master/lib/pagy.rb), [pagy/backend.rb](https://github.com/ddnexus/pagy/blob/master/lib/pagy/backend.rb), [pagy/frontend.rb](https://github.com/ddnexus/pagy/blob/master/lib/pagy/frontend.rb) 
+* paginates using one micro-class that creates a micro-object of less than 3k. 
+* knows **nothing** about your environment, 
+* is compatible with Rack frameworks like: Rails, Sinatra, Padrino etc, and even pure Ruby without Rack.
+* is highly performant.
 
-Pagy is very specialized. It uses its own code to produce its own HTML, URLs, pluralization and interpolation. Unlike other gems it does not use any generic helpers such as rails helpers (`tag`, `link_to`, `url_for`, `I18n.t`, ...).
+## Uses specialized code instead of generic helpers
 
-Those are perfect helpers but only if used _in an application_.  Because _they are generic_ they can get the job done in any situation, but exactly _because they are generic_, they are just the wrong tool to use _in a pagination gem_. Indeed they are inevitably A LOT slower and use A LOT more memory than specialized methods (or no method at all, like in case of HTML string interpolation extensively used by Pagy).
+Pagy uses its own code to produce its own HTML, URLs, pluralization and interpolation. Generic helpers are avoided (`tag`, `link_to`, `url_for`, `I18n.t`, ...), because Pagy's specialized methods are significantly more performant. 
 
-## Stay away from the models
+## Stays away from models
 
-**Paginating is not business logic**: it has nothing to do with the data itself. It has to do with the way you decide to _present_ the data... one page at the time, n items per page... That is indeed _presentation_ logic, so the models are really not the place where to add that logic!
+**Paginating is not business logic**: it has nothing to do with the data itself, but with how the data is *presented:* e.g. ... one page at the time, n items per page ... should such logic really live in your models? Pagy doesn't think so!
 
-**Every collection knows already how to paginate itself**: that's what OFFSET and LIMIT in DBs are for! You decide the limit (the items per page) and Pagy (or yourself) can calculate the offset with simple arithmetic: `offset = items * (page - 1)`. That's not rocket science! You don't need to add a bunch of methods to your models just to get the page records!
+**Every collection knows already how to paginate itself**: that's what OFFSET and LIMIT in DBs are for! You decide the limit (the items per page) and Pagy (or yourself) can calculate the offset with simple arithmetic: `offset = items * (page - 1)`. That's not rocket science! 
 
-Ignoring these simple rules has a lot of drawbacks for performance, memory, maintenance, complexity and usability, as you can confirm with the [Gems Comparison page](http://ddnexus.github.io/pagination-comparison).
-
-## No rails engine needed
-
-You don't need a rails engine for a simple task like pagination: you just need a few lines of plain ruby to get it right, fast and light in **any** framework, not just rails.
-
-## Really agnostic pagination
-
-Pagy provides the clean logic of pagination in one micro-class that creates a micro-object of less than 3k: it works perfectly, knowing **absolutely nothing** about your environment. _(see the [source](https://github.com/ddnexus/pagy/blob/master/lib/pagy.rb))_
-
-You could even use it directly (without using any other Pagy code) in a small partial template that you could write in just 5 minutes and about 15 lines. There you could use the regular helpers provided by your framework and it would still work a few times faster than using other gems, even without using any Pagy template nor any other Pagy method.
+Ignoring these rules come with drawbacks in: performance, memory, maintenance, complexity and usability - see the [gems Comparison page](http://ddnexus.github.io/pagination-comparison).
 
 ## Really easy to customize
 
-If options and configuration are not enough, you have a several specialized [extras](/categories/extras), and if all that is still not enough, any other special customization is at most _one step far_ from your own code. You include them in your code, so you can override any method right where you use it: no tricky gimmickry required.
+Pagy is eminently customizable: consider its options and specialized [extras](/categories/extras), and if that is not enough, special customization is at most _one step far_ from your own code. Simply override a method right where you use it: no tricky gimmickry required.
 
 What could be easier?
+


### PR DESCRIPTION
### What changed?

- intro is significantly shorter (41% shorter)
- the wording is more precise, certain parts omitted given it's a pure introductory passage.
- dot points used when enumerating.

### Why?

* shorter is sweeter.

I hope it helps. if not, feel free to discard.


