### PR TITLE
docs: open applicable retype panels by default

### DIFF
--- a/docs/extras/bootstrap.md
+++ b/docs/extras/bootstrap.md
@@ -49,7 +49,7 @@ This extra adds 3 nav helpers to the `Pagy::Frontend` module.
 You can customize them by overriding in your own view helper(s).
 !!!
 
-==- `pagy_bootstrap_nav(pagy, ...)`
+=== `pagy_bootstrap_nav(pagy, ...)`
 
 ![pagy_bootstrap_nav](/docs/assets/images/bootstrap_nav.png)
 

--- a/docs/extras/materialize.md
+++ b/docs/extras/materialize.md
@@ -36,7 +36,7 @@ See [Javascript](/docs/api/javascript.md) if you use `pagy_materialize_nav_js` o
 
 This extra adds 3 nav helpers to the `Pagy::Frontend` module. You can customize them by direct overriding in your own view helper.
 
-==- `pagy_materialize_nav(pagy)`
+=== `pagy_materialize_nav(pagy)`
 
 ![materialize_nav](/docs/assets/images/materialize_nav.png)
 

--- a/docs/extras/semantic.md
+++ b/docs/extras/semantic.md
@@ -33,7 +33,7 @@ require 'pagy/extras/semantic'
 
 This extra adds 3 nav helpers to the `Pagy::Frontend` module. You can customize them by direct overriding in your own view helper.
 
-==- `pagy_semantic_nav(pagy)`
+=== `pagy_semantic_nav(pagy)`
 
 ![semantic_nav](/docs/assets/images/semantic_nav.png)
 
@@ -51,7 +51,7 @@ To do: Add a proper responsive image for semantic, as we have done for bootstrap
 
 See: [Javascript Navs](/docs/api/javascript/navs.md).
 
-==- `pagy_semantic_combo_nav_js(pagy, ...)`
+=== `pagy_semantic_combo_nav_js(pagy, ...)`
 
 ![semantic_combo_nav_js](/docs/assets/images/semantic_combo_nav_js.png)
 


### PR DESCRIPTION
What is this?

* Panels with images within them are closed. They should be opened, so users can see what is inside. This PR addresses this.


![image](https://user-images.githubusercontent.com/15097447/217437172-ec76baa0-4e1f-46ea-97eb-49e2835ccfec.png)
