### PR TITLE
docs: fix typo - the wrong extra was being loaded

### DIFF
--- a/docs/extras/i18n.md
+++ b/docs/extras/i18n.md
@@ -23,7 +23,7 @@ Having the `i18n` gem already installed and configured in your app might not cou
 
 ||| pagy.rb (initializer)
 ```ruby
-require 'pagy/extras/headers'
+require 'pagy/extras/i18n'
 ```
 |||
 


### PR DESCRIPTION
* Fix for: https://github.com/ddnexus/pagy/issues/459

Thank you to @Birdie0 for the contribution.

Caveat with PR:

* I have not loaded and tested on a production app: but it looks simple enough.