### PR TITLE
Docs: Add docs to Pagy::Console (fixes #481)

### DIFF
--- a/docs/api/console.md
+++ b/docs/api/console.md
@@ -6,7 +6,7 @@ categories:
 
 # Pagy::Console
 
-Allows you to test Pagy in an irb with an environment stubbed for you:
+Allows you to test Pagy in an [irb](https://github.com/ruby/irb) with an environment stubbed for you:
 
 <details>
 
@@ -51,14 +51,14 @@ pagy_metadata(pagy)
 
 Avoid using `rails console` with `Pagy::Console`.
 
-Use `irb` instead. However, if you need `rails console` please ensure you do not freeze the `Pagy::DEFAULT` hash, in your `pagy.rb` config file, otherwise you'll receive a "can't modify frozen Hash" exception:
+Use `irb` instead. However, if you need `rails console` please ensure temporarily  "unfreeze" the `Pagy::DEFAULT` hash, in your `pagy.rb` config file, otherwise you'll receive a "can't modify frozen Hash" exception:
 
 ```rb
 # Pagy::DEFAULT.freeze  ## temporarily comment out this line
 ```
 !!!
 
-Now follow the instructions in the irb tab.
+Now, refer to the instructions in the [irb tab](#irb).
 
 +++
 

--- a/docs/api/console.md
+++ b/docs/api/console.md
@@ -6,12 +6,17 @@ categories:
 
 # Pagy::Console
 
-Use pagy in the irb/rails console even without any app nor configuration.
+Allows you to test Pagy in an irb with an environment stubbed for you:
 
-Standard pagination requires controller, model, view and request to work, however you don't have to satisfy all that requirements in order to get any helper working in the irb/rails console.
+<details>
 
-You can try any pagy feature right away:
+Standard pagination requires controller, model, view and request to work. `Pagy::Console` stubs all of that for you, automatically. 
 
+</details>
+
+</br>
+
++++ irb
 ```ruby
 require 'pagy/console'
 include Pagy::Console
@@ -40,6 +45,22 @@ pagy_metadata(pagy)
    :size=>[1, 4, 4, 1],
 ...
 ```
++++ rails console
+
+!!!warning Warning
+
+Avoid using `rails console` with `Pagy::Console`.
+
+Use `irb` instead. However, if you need `rails console` please ensure you do not freeze the `Pagy::DEFAULT` hash, in your `pagy.rb` config file, otherwise you'll receive a "can't modify frozen Hash" exception:
+
+```rb
+# Pagy::DEFAULT.freeze  ## temporarily comment out this line
+```
+!!!
+
+Now follow the instructions in the irb tab.
+
++++
 
 ## Pagy::Console module
 

--- a/docs/api/console.md
+++ b/docs/api/console.md
@@ -10,7 +10,7 @@ Allows you to test Pagy in an [irb](https://github.com/ruby/irb) with an environ
 
 <details>
 
-Standard pagination requires controller, model, view and request to work. `Pagy::Console` stubs all of that for you, automatically. 
+Standard pagination requires a: controller, model, view and request object to work i.e. you need an environment. `Pagy::Console` gives you that environment. 
 
 </details>
 
@@ -51,10 +51,10 @@ pagy_metadata(pagy)
 
 Avoid using `rails console` with `Pagy::Console`.
 
-Use `irb` instead. However, if you need `rails console` please ensure temporarily  "unfreeze" the `Pagy::DEFAULT` hash, in your `pagy.rb` config file, otherwise you'll receive a "can't modify frozen Hash" exception:
+Use `irb` instead. However, if you need `rails console` please ensure you temporarily "unfreeze" the `Pagy::DEFAULT` hash, in your `pagy.rb` config file, otherwise you'll receive a "can't modify frozen Hash" exception:
 
 ```rb
-# Pagy::DEFAULT.freeze  ## temporarily comment out this line
+# Pagy::DEFAULT.freeze  ## temporarily comment out this line, don't forget to uncomment when finished!
 ```
 !!!
 


### PR DESCRIPTION
Fix: for https://github.com/ddnexus/pagy/issues/481

What's the problem?

There seems to be some confusion on Pagy::Console's use: "can we use it with `rails console`?"

