### PR TITLE
Docs: simplify warning re: pagy_array

### DIFF
--- a/docs/extras/array.md
+++ b/docs/extras/array.md
@@ -9,43 +9,24 @@ categories:
 
 Paginate arrays efficiently.
 
-!!! warning WARNING
-The `array` extra is efficient if you need to paginate an array, but if the data in the array comes from some DB or other persisted storage (i.e. not some in-memory storage), DO NOT use the array extra.
-!!!
-
-+++ Bad
-!!!danger Do not:
+!!!danger Bad - do not do this:
 ```rb
 def index 
     @pagy, @comments = pagy_array(Comment.all.to_a) # no! wasting memory
 end
 ```
-There is no need to use `pagy_array` extra here because we are retrieving from a database.
-
-Do this instead:
-```rb
-# good
-def index 
-    @pagy, @comments = pagy(Comment.all) # pagy method, instead of pagy_array
-end
-```
-
+Do not use `pagy_array` with any persistent storage collection (database, elastic search, Meilisearch etc) because it will not be performant.
 !!!
 
-+++ Good
-!!!success DO:
+
+!!!success Good:
 ```rb
 def index 
-    @pagy, @special_items = pagy_array([1,2,3,4]) # items not retrieved from DB.
+    @pagy, @special_items = pagy_array(array_not_from_db) 
 end
 ```
-Use only if you are not retrieving from a database.
-
-+++
-
-
-
-
+Use with collections that are already loaded in memory. (e.g. arrays of cached indices, keys of hashes, pointers, etc.).
+!!!
 
 ## Synopsis
 

--- a/docs/extras/array.md
+++ b/docs/extras/array.md
@@ -10,14 +10,42 @@ categories:
 Paginate arrays efficiently.
 
 !!! warning WARNING
-This warning may sound obvious, but I keep finding people improperly using this extra, so let me write it explicitly.
-
-The `array` extra is efficient if you really need to paginate an array, but if the data in the array comes from some DB or other persisted storage (i.e. not some in-memory storage), then you should definitely review your code!
-
-You should not pull the whole collection into an array (potentially wasting tons of memory), when you can pull just a single page of it by using the standard `@page, @records = pagy(your_scope)`.
-
-And if you think that it's the only way to do what you need, then... think again. 🧐
+The `array` extra is efficient if you need to paginate an array, but if the data in the array comes from some DB or other persisted storage (i.e. not some in-memory storage), DO NOT use the array extra.
 !!!
+
++++ Bad
+!!!danger Do not:
+```rb
+def index 
+    @pagy, @comments = pagy_array(Comment.all.to_a) # no! wasting memory
+end
+```
+There is no need to use `pagy_array` extra here because we are retrieving from a database.
+
+Do this instead:
+```rb
+# good
+def index 
+    @pagy, @comments = pagy(Comment.all) # pagy method, instead of pagy_array
+end
+```
+
+!!!
+
++++ Good
+!!!success DO:
+```rb
+def index 
+    @pagy, @special_items = pagy_array([1,2,3,4]) # items not retrieved from DB.
+end
+```
+Use only if you are not retrieving from a database.
+
++++
+
+
+
+
 
 ## Synopsis
 

--- a/docs/extras/array.md
+++ b/docs/extras/array.md
@@ -9,20 +9,20 @@ categories:
 
 Paginate arrays efficiently.
 
-!!!danger Bad - do not do this:
+!!!danger Bad!
 ```rb
 def index 
-    @pagy, @comments = pagy_array(Comment.all.to_a) # no! wasting memory
+    @pagy, @comments = pagy_array(Comment.all.to_a) # your code is wasting memory!
 end
 ```
-Do not use `pagy_array` with any persistent storage collection (database, elastic search, Meilisearch etc) because it will not be performant.
+Do not use `pagy_array` with any persistent storage collection (database, elastic search, Meilisearch etc)!
 !!!
 
 
-!!!success Good:
+!!!success Good
 ```rb
 def index 
-    @pagy, @special_items = pagy_array(array_not_from_db) 
+    @pagy, @special_items = pagy_array(array_from_memory) 
 end
 ```
 Use with collections that are already loaded in memory. (e.g. arrays of cached indices, keys of hashes, pointers, etc.).


### PR DESCRIPTION
Why?

Fix for: https://github.com/ddnexus/pagy/discussions/514

Looks like too many people are misusing this extra.  I think the current warning was not obvious enough? I thought why not shorten the warning and make it really obvious with red danger signs: 

![do not do](https://user-images.githubusercontent.com/15097447/236710923-b8b2742d-a4c9-4ca6-baab-91dc46024970.png)





