### PR TITLE
Remove runtime dependency on base64

### DIFF
--- a/lib/pagy/extras/frontend_helpers.rb
+++ b/lib/pagy/extras/frontend_helpers.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'base64'
-
 class Pagy # :nodoc:
   DEFAULT[:steps] = false # default false will use {0 => @vars[:size]}
 
@@ -48,7 +46,8 @@ class Pagy # :nodoc:
         # Base64 encoded JSON is smaller than HTML escaped JSON
         def pagy_data(pagy, *args)
           args << pagy.vars[:page_param] if pagy.vars[:trim_extra]
-          %(data-pagy="#{Base64.strict_encode64(Oj.dump(args, mode: :strict))}")
+          strict_base64_encoded = [Oj.dump(args, mode: :strict)].pack('m0')
+          %(data-pagy="#{strict_base64_encoded}")
         end
       else
         require 'json'
@@ -56,7 +55,8 @@ class Pagy # :nodoc:
         # Base64 encoded JSON is smaller than HTML escaped JSON
         def pagy_data(pagy, *args)
           args << pagy.vars[:page_param] if pagy.vars[:trim_extra]
-          %(data-pagy="#{Base64.strict_encode64(args.to_json)}")
+          strict_base64_encoded = [args.to_json].pack('m0')
+          %(data-pagy="#{strict_base64_encoded}")
         end
       end
 


### PR DESCRIPTION
Ruby 3.3 prints a warning if base64 is used without specifying it in the gemfile. Ruby 3.4 will error.
Since it's just a wrapper around the pack/unpack methods it's trivial to replace.

You don't see this in CI since the Gemfile contains dependencies that in turn already depend on `base64`, like `activesupport`.

Here is some similar work:
* https://github.com/rack/rack/pull/2110
* https://github.com/rubocop/rubocop/pull/12313
* https://github.com/sidekiq/sidekiq/pull/6151
* https://github.com/opensearch-project/opensearch-ruby/pull/221
* https://github.com/lostisland/faraday/pull/1541
* https://github.com/newrelic/newrelic-ruby-agent/pull/2378
