### PR TITLE
Docs: fix - add quotes around event handlers

### DIFF
--- a/docs/api/javascript/setup.md
+++ b/docs/api/javascript/setup.md
@@ -298,10 +298,10 @@ window.addEventListener("turbo:load", Pagy.init);
 import Pagy from "pagy-module"
 
 // plain javascript
-window.addEventListener(load, Pagy.init)
+window.addEventListener("load", Pagy.init)
 
 // Turbo
-window.addEventListener(turbo:load, Pagy.init)
+window.addEventListener("turbo:load", Pagy.init)
 
 // Turbolinks
 window.addEventListener("turbolinks:load", Pagy.init)


### PR DESCRIPTION
credit to: @creativetags - Mark Robinson as per this PR: https://github.com/ddnexus/pagy/pull/619

