### PR TITLE
Docs: add link with instructions on adding new langauges

### DIFF
--- a/docs/api/i18n.md
+++ b/docs/api/i18n.md
@@ -99,3 +99,7 @@ en:
 ```
 
 _(See also the [pagy_info method](frontend/#pagy-info-pagy-pagy-id-item-name-i18n-key) and [How to customize the item name](/docs/how-to.md#customize-the-item-name))_
+
+## Contribute a language
+
+If you wish to add a new locale to pagy ([see existing locales in the lib/locales directory](https://github.com/ddnexus/pagy/tree/master/lib/locales)) please follow the [locales  readme instructions here.](https://github.com/ddnexus/pagy/blob/master/lib/locales/README.md).


### PR DESCRIPTION
Why?

* to make this information easier to find / more transparent (I could not find it myself).