### PR TITLE
Change `en` `prev_label` translation (closes #576)

### DIFF
--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -12,7 +12,7 @@ en:
       other: "items"
 
     nav:
-      prev_label: "Prev"
+      prev_label: "Previous"
       next_label: "Next"
       prev: "&lt;"
       next: "&gt;"


### PR DESCRIPTION
Addresses opportunity for non-abbreviated "previous", as discussed [here](https://github.com/ddnexus/pagy/discussions/569#discussioncomment-8292672)