### PR TITLE
Docs: update tailind styling for pagy + 7.0

### DIFF
--- a/docs/extras/tailwind.md
+++ b/docs/extras/tailwind.md
@@ -46,11 +46,11 @@ simply paste the following into your `tailwind.css` file.
   @apply flex space-x-2;
 }
 
-.pagy-nav .page a,
+.pagy-nav .page a[href],
 .pagy-nav .page.active,
 .pagy-nav .page.prev.disabled,
 .pagy-nav .page.next.disabled,
-.pagy-nav-js .page a,
+.pagy-nav-js .page a[href],
 .pagy-nav-js .page.active,
 .pagy-nav-js .page.prev.disabled,
 .pagy-nav-js .page.next.disabled {
@@ -87,7 +87,6 @@ simply paste the following into your `tailwind.css` file.
   }
 }
 
-
 .pagy-combo-nav-js {
   @apply flex max-w-max rounded-full px-3 py-1 text-sm text-gray-500 font-semibold bg-gray-200 shadow-md;
 }
@@ -118,7 +117,7 @@ simply paste the following into your `tailwind.css` file.
 
 ![Image of Style 2](../assets/images/tailwind-example-style-2.png)
 
-||| CSS Rules
+||| CSS Rules  
 
 ```scss
 @import "~tailwindcss/base"; 
@@ -139,23 +138,22 @@ simply paste the following into your `tailwind.css` file.
   @apply relative inline-flex items-center rounded-l-md border border-gray-300 bg-white px-2 py-2 text-sm font-medium text-gray-500 hover:bg-gray-50 focus:z-20;
 }
 
-.page.next.disabled {
-  @apply relative inline-flex items-center rounded-r-md border border-gray-300 bg-slate-100 px-2 py-2 text-sm font-medium text-gray-500 hover:bg-gray-50 focus:z-20;
+.page.next.disabled a {
+  @apply relative inline-flex items-center rounded-r-md border border-gray-300 bg-slate-100 px-2 py-2 text-sm font-medium text-gray-500 focus:z-20;
 }
 
-.page.prev.disabled {
-  @apply relative inline-flex items-center rounded-l-md border border-gray-300 bg-slate-100 px-2 py-2 text-sm font-medium text-gray-500 hover:bg-gray-50 focus:z-20;
+.page.prev.disabled a {
+  @apply relative inline-flex items-center rounded-l-md border border-gray-300 bg-slate-100 px-2 py-2 text-sm font-medium text-gray-500 focus:z-20;
 }
 
 .page a, .page.gap {
   @apply bg-white border-gray-300 text-gray-500 hover:bg-gray-50 relative inline-flex items-center border px-4 py-2 text-sm font-medium focus:z-20;
 }
 
-.page.active {
+.page.active a {
   @apply z-10 border-indigo-500 bg-indigo-50 text-indigo-600 relative inline-flex items-center border px-4 py-2 text-sm font-medium focus:z-20;
 }
 ```
-
 |||
 
 +++


### PR DESCRIPTION
Why?

* Some html elements were not being targeted by the selector.

What changed?

* for the second styles - we need not use the href attriute selector. a simple a selector will suffice.

Couple of minor points:

* the second style targets the 'pagination' class while the first does not. It is of no consequences.
* the second style does not target nav-js styles.
* the second style: when disabled i removed the 'hover' styling.

Authored by Benjamin Block.