### PR TITLE
Update cs translations

### DIFF
--- a/lib/locales/cs.yml
+++ b/lib/locales/cs.yml
@@ -3,7 +3,7 @@ cs:
   pagy:
     aria_label:
       nav:
-       # skip the "few" variant as this word is used as a bare plural without the numeral
+       # use the "few" variant for all plurals as this word is used as a bare plural without the numeral
        one: "Stránka"
        other: "Stránky"
       prev: "Předchozí"

--- a/lib/locales/cs.yml
+++ b/lib/locales/cs.yml
@@ -1,8 +1,6 @@
 # :west_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
 cs:
   pagy:
-    # please add a comment in the https://github.com/ddnexus/pagy/issues/582
-    # posting the translation of the following  "Page"/"Pages" with the plurals for this locale
     aria_label:
       nav:
        # skip the "few" variant as this word is used as a bare plural without the numeral

--- a/lib/locales/cs.yml
+++ b/lib/locales/cs.yml
@@ -15,11 +15,11 @@ cs:
     gap: "&hellip;"
     item_name:
       one: "položka"
-      few: "položek"
-      other: "položky"
+      few: "položky"
+      other: "položek"
     info:
       no_items: "Nic nebylo nalezeno"
       single_page: "Zobrazeno <b>%{count}</b> %{item_name}"
-      multiple_pages: "Zobrazeno %{item_name} <b>%{from}-%{to}</b> z <b>%{count}</b> celkem"
+      multiple_pages: "Zobrazeny položky <b>%{from}-%{to}</b> z <b>%{count}</b> celkem"
     combo_nav_js: "<label>Strana %{page_input} z %{pages}</label>"
     items_selector_js: "<label>Zobrazit %{items_input} %{item_name} na stránce</label>"

--- a/lib/locales/cs.yml
+++ b/lib/locales/cs.yml
@@ -4,10 +4,10 @@ cs:
     # please add a comment in the https://github.com/ddnexus/pagy/issues/582
     # posting the translation of the following  "Page"/"Pages" with the plurals for this locale
     aria_label:
-      nav: "Pages"
-#        one: ""
-#        few: ""
-#        other: ""
+      nav:
+       # skip the "few" variant as this word is used as a bare plural without the numeral
+       one: "Stránka"
+       other: "Stránky"
       prev: "Předchozí"
       next: "Další"
     prev: "&lt;"


### PR DESCRIPTION
Hello! This is my attempt to resolve the Czech translations needed in #582. In the end it was a bit more complex than expected so let me explain my changes a little bit more:

The problem with Czech pluralization is that the bare plural word for e.g. "items", used _without_ the numeral, is often different from the plural word when used together _with_ the numeral: It's "položky" vs. "10 položek", for example. In fact, a bare Czech plural word probably always uses the `few` variant in the i18n dictionary.

#### Aria labels

Aria label uses the pluralized word for "Pages" but in the bare form, without the numeral. That's why I used only the `other` variant in the dictionary (but with a plural form for the "few" variant of "Pages") to correctly distinguish between a single "page" and multiple "pages"  only.

#### Item_name fixes

While doing that, I noticed that the `item_name` translations were incorrect. The `few` and `other` items in the dictionary were swapped so I fixed them. 

And also, the `multiple_pages` label has to use the "bare" plural form, because it says "Items shown X-Y from Z" and not "N items shown..." and as such the `item_name` can be replaced with a static string. This still has one edge case when showing only 1 item, it will show: "Zobrazeny položky 1-1 z 1" (i.e. a plural form) instead of the more correct singular form: "Zobrazena položka 1-1 z 1" but this is not possible to do without pluralizing the word "Zobrazena" ("shown"), too. But it's not an important edge case, I guess, and it doesn't sound _that_ weird either.