### PR TITLE
Expand/Correct changes about `pagy.prev` and `pagy.next`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,8 +79,8 @@ None
 ### Visual changes (possibly breaking test/views)
 
 - The ARIA label compliance required the refactoring of all the nav helpers that might look slightly different now:
-  - The text for `"Previous"` and `"Next"` is now used for the `aria-label` and has been replaced in the UI as `<` and `>`. You
-    can edit the dictionary entries if you want to revert it to the previous default (`< Prev` and `Next >`)
+  - The text for `"Prev"` and `"Next"` is now used for the `aria-label` and has been replaced in the UI as `<` and `>`. You
+    can edit the dictionary entries `pagy.prev` and `pagy.next` if you want to revert it to the previous default (`&lsaquo;&nbsp;Prev` and `Next&nbsp;&rsaquo;`)
 
 ### CSS changes (possibly looking different/broken)
 


### PR DESCRIPTION
Adds notes about which keys you need to tweak in order to modify the previous/next page text.

It also changes "Previous" to "Prev", that was changed in https://github.com/ddnexus/pagy/commit/56ab22150844786439511c93f84b25331e49c2af#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR64 but I don't think thats correct.

Lastly corrects the previous default. It wasn't just plain < and >. I used html entities but it might make sense to use actual characters for the purpose of the changelog.