### PR TITLE
Fix some formatting in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,18 @@ See the [Detailed Gems Comparison](http://ddnexus.github.io/pagination-compariso
 
 ## 🤩 It does it all. Better.
 
-- **It works in any environment**<br>With Rack frameworks (Rails, Sinatra, Padrino, etc.) or in pure ruby without Rack
-- **It works with any collection**<br>With any ORM, any DB, any search
+- **It works in any environment**  
+  With Rack frameworks (Rails, Sinatra, Padrino, etc.) or in pure ruby without Rack
+- **It works with any collection**  
+  With any ORM, any DB, any search
   gem, [elasticsearch_rails](https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails), [meilisearch](https://ddnexus.github.io/pagy/docs/extras/meilisearch), [searchkick](https://ddnexus.github.io/pagy/docs/extras/searchkick), `ransack`,
   and just any list, even if you cannot count it
-- **It supports all kinds of pagination
-  **<br>[calendar](https://ddnexus.github.io/pagy/docs/extras/calendar "paginates by dates, rather than numbers"), [countless](https://ddnexus.github.io/pagy/docs/extras/countless "skips an extra 'count' query"), [geared](https://ddnexus.github.io/pagy/docs/extras/gearbox "varies the items fetched depending on the page number e.g. page 1: x items, but page 2: y items etc."), [incremental, auto-incremental, infinite](https://ddnexus.github.io/pagy/docs/extras/support), [headers](https://ddnexus.github.io/pagy/docs/extras/headers "useful for API pagination"), [JSON](https://ddnexus.github.io/pagy/docs/extras/metadata "provides pagination metadata - especially useful with frameworks like Vue, React etc. and you want to render your own pagination links"), [cursor](https://github.com/Uysim/pagy-cursor "Useful with large data sets, where performance becomes a concern (separate repository)")
-- **It supports all kinds of CSS Frameworks
-  **<br>[bootstrap](https://ddnexus.github.io/pagy/docs/extras/bootstrap), [bulma](https://ddnexus.github.io/pagy/docs/extras/bulma), [foundation](https://ddnexus.github.io/pagy/docs/extras/foundation), [materialize](https://ddnexus.github.io/pagy/docs/extras/materialize), [semantic](https://ddnexus.github.io/pagy/docs/extras/semantic), [uikit](https://ddnexus.github.io/pagy/docs/extras/uikit), [tailwind](https://ddnexus.github.io/pagy/docs/extras/tailwind)
-- **It supports faster client-side rendering**<br>With classic or innovative UI components (
+- **It supports all kinds of pagination**  
+  [calendar](https://ddnexus.github.io/pagy/docs/extras/calendar "paginates by dates, rather than numbers"), [countless](https://ddnexus.github.io/pagy/docs/extras/countless "skips an extra 'count' query"), [geared](https://ddnexus.github.io/pagy/docs/extras/gearbox "varies the items fetched depending on the page number e.g. page 1: x items, but page 2: y items etc."), [incremental, auto-incremental, infinite](https://ddnexus.github.io/pagy/docs/extras/support), [headers](https://ddnexus.github.io/pagy/docs/extras/headers "useful for API pagination"), [JSON](https://ddnexus.github.io/pagy/docs/extras/metadata "provides pagination metadata - especially useful with frameworks like Vue, React etc. and you want to render your own pagination links"), [cursor](https://github.com/Uysim/pagy-cursor "Useful with large data sets, where performance becomes a concern (separate repository)")
+- **It supports all kinds of CSS Frameworks**  
+  [bootstrap](https://ddnexus.github.io/pagy/docs/extras/bootstrap), [bulma](https://ddnexus.github.io/pagy/docs/extras/bulma), [foundation](https://ddnexus.github.io/pagy/docs/extras/foundation), [materialize](https://ddnexus.github.io/pagy/docs/extras/materialize), [semantic](https://ddnexus.github.io/pagy/docs/extras/semantic), [uikit](https://ddnexus.github.io/pagy/docs/extras/uikit), [tailwind](https://ddnexus.github.io/pagy/docs/extras/tailwind)
+- **It supports faster client-side rendering**  
+  With classic or innovative UI components (
   see [Javascript Components](https://ddnexus.github.io/pagy/docs/api/javascript/)) or by
   serving [JSON](https://ddnexus.github.io/pagy/docs/extras/metadata) to your favorite Javascript framework
 - **It has 100% of test coverage** for Ruby, HTML and Javascript E2E (


### PR DESCRIPTION
![grafik](https://github.com/ddnexus/pagy/assets/14981592/150e1552-e445-42cd-b923-ca0dc2cb272e)

I've moved the text for all entries below the header, the two that currently don't reder well were doing that already.The text more closely resembles the rendered output that way. To do this, appending two spaces at the end of a line forces a linebreak.