### PR TITLE
Docs: fix broken links

### DIFF
--- a/docs/api/stylesheets.md
+++ b/docs/api/stylesheets.md
@@ -17,7 +17,7 @@ untouched
 
 +++ pagy.scss
 
-[!file](/lib/stylesheets/pagy.scss)
+[Download file](/lib/stylesheets/pagy.scss)
 
 ```ruby 
 stylesheet_path = Pagy.root.join('stylesheets', 'pagy.scss')
@@ -27,7 +27,7 @@ stylesheet_path = Pagy.root.join('stylesheets', 'pagy.scss')
 
 +++ pagy.css
 
-[!file](/lib/stylesheets/pagy.css)
+[Download file](/lib/stylesheets/pagy.css)
 
 ```ruby 
 stylesheet_path = Pagy.root.join('stylesheets', 'pagy.css')
@@ -37,7 +37,7 @@ stylesheet_path = Pagy.root.join('stylesheets', 'pagy.css')
 
 +++ pagy.tailwind.scss
 
-[!file](/lib/stylesheets/pagy.tailwind.scss)
+[Download file](/lib/stylesheets/pagy.tailwind.scss)
 
 ```ruby 
 stylesheet_path = Pagy.root.join('stylesheets', 'pagy.tailwind.scss')


### PR DESCRIPTION
* The links are not actually broken.
* I could only make it trigger a download by change the style of the links. A temporary solution till a true one is found.

Try it out here: https://benkoshy.github.io/pagy/docs/api/stylesheets/


To close issue raised here: https://github.com/ddnexus/pagy/commit/ce9365daae630a6699c925437d0b96d9dc79581f

