### PR TITLE
Fix jsonapi prev and next keys for unavailable links

### DIFF
--- a/lib/pagy/extras/jsonapi.rb
+++ b/lib/pagy/extras/jsonapi.rb
@@ -26,8 +26,8 @@ class Pagy # :nodoc:
       def pagy_jsonapi_links(pagy, **opts)
         { first: pagy_url_for(pagy, 1,         **opts),
           last:  pagy_url_for(pagy, pagy.last, **opts),
-          prev:  pagy_url_for(pagy, pagy.prev, **opts),
-          next:  pagy_url_for(pagy, pagy.next, **opts) }
+          prev:  pagy.prev ? pagy_url_for(pagy, pagy.prev, **opts) : nil,
+          next:  pagy.next ? pagy_url_for(pagy, pagy.next, **opts) : nil }
       end
 
       # Should skip the jsonapi

--- a/test/pagy/extras/jsonapi_test.rb
+++ b/test/pagy/extras/jsonapi_test.rb
@@ -21,7 +21,7 @@ describe 'pagy/extras/jsonapi' do
     _ { _pagy, _records = app.send(:pagy, @collection) }.must_raise Pagy::JsonApiExtra::ReservedParamError
   end
 
-  describe "JsonApi" do
+  describe 'JsonApi' do
     it 'uses the :jsonapi with page:nil' do
       app = MockApp.new(params: { page: nil })
       pagy, _records = app.send(:pagy, @collection, items_extra: false)
@@ -37,46 +37,58 @@ describe 'pagy/extras/jsonapi' do
       _(app.send(:pagy_url_for, pagy, 2)).must_rematch :url_2
     end
   end
-  describe "Skip JsonApi" do
+  describe 'Skip JsonApi' do
     it 'skips the :jsonapi with page:nil' do
       Pagy::DEFAULT[:jsonapi] = false
       app = MockApp.new(params: { page: nil })
       pagy, _records = app.send(:pagy, @collection, items_extra: false)
-      _(app.send(:pagy_url_for, pagy, 1)).must_equal "/foo?page=1"
+      _(app.send(:pagy_url_for, pagy, 1)).must_equal '/foo?page=1'
       pagy, _records = app.send(:pagy, @collection)
-      _(app.send(:pagy_url_for, pagy, 1)).must_equal "/foo?page=1&items=20"
+      _(app.send(:pagy_url_for, pagy, 1)).must_equal '/foo?page=1&items=20'
       Pagy::DEFAULT[:jsonapi] = true
     end
     it 'skips the :jsonapi with page:3' do
       Pagy::DEFAULT[:jsonapi] = false
       app = MockApp.new(params: { page: 3 })
       pagy, _records = app.send(:pagy, @collection, items_extra: false)
-      _(app.send(:pagy_url_for, pagy, 2)).must_equal "/foo?page=2"
+      _(app.send(:pagy_url_for, pagy, 2)).must_equal '/foo?page=2'
       pagy, _records = app.send(:pagy, @collection)
-      _(app.send(:pagy_url_for, pagy, 2)).must_equal "/foo?page=2&items=20"
+      _(app.send(:pagy_url_for, pagy, 2)).must_equal '/foo?page=2&items=20'
       Pagy::DEFAULT[:jsonapi] = true
     end
   end
-  describe "JsonApi with custom named params" do
-    it "gets custom named params" do
+  describe 'JsonApi with custom named params' do
+    it 'gets custom named params' do
       app = MockApp.new(params: { page: { number: 3, size: 10 } })
       pagy, _records = app.send(:pagy, @collection, page_param: :number, items_param: :size)
       _(pagy.page).must_equal 3
       _(pagy.items).must_equal 10
     end
-    it "sets custom named params" do
+    it 'sets custom named params' do
       app = MockApp.new(params: { page: { number: 3, size: 10 } })
       pagy, _records = app.send(:pagy, @collection, page_param: :number, items_param: :size)
       _(app.send(:pagy_url_for, pagy, 4)).must_rematch :url
     end
   end
-  describe "#pagy_jsonapi_links" do
-    it "returns the ordered links" do
+  describe '#pagy_jsonapi_links' do
+    it 'returns the ordered links' do
       app = MockApp.new(params: { page: { number: 3, size: 10 } })
       pagy, _records = app.send(:pagy, @collection, page_param: :number, items_param: :size)
       result = app.send(:pagy_jsonapi_links, pagy)
       _(result.keys).must_equal %i[first last prev next] # not sure it's a requirementS
       _(result).must_rematch :result
+    end
+    it 'sets the prev value to null when the link is unavailable' do
+      app = MockApp.new(params: { page: { page: 1 } })
+      pagy, _records = app.send(:pagy, @collection)
+      result = app.send(:pagy_jsonapi_links, pagy)
+      _(result[:prev]).must_be_nil
+    end
+    it 'sets the next value to null when the link is unavailable' do
+      app = MockApp.new(params: { page: { page: 50 } })
+      pagy, _records = app.send(:pagy, @collection)
+      result = app.send(:pagy_jsonapi_links, pagy)
+      _(result[:next]).must_be_nil
     end
   end
 end


### PR DESCRIPTION
Hi @ddnexus, thank you so much for this awesome Gem 💎

I came across an issue when using the `Jsonapi` extra.

### The Problem

I'm getting a `expected :page >= 1; got 0` exception when following a `prev` or `next` link with no content.

<img width="890" alt="Screenshot 2024-03-15 at 07 58 01" src="https://github.com/ddnexus/pagy/assets/3071529/bbb20e8d-0417-4af9-b777-3666c803c2a9">

---

<img width="890" alt="Screenshot 2024-03-15 at 08 23 50" src="https://github.com/ddnexus/pagy/assets/3071529/e32e5015-8b0c-4479-ac25-ffb8d66de8d1">

---

### The Fix

According to the [JSON:API spec](https://jsonapi.org/format/#fetching-pagination), it specifies to omit the key or return `null` for unavailable links.

<img width="1205" alt="Screenshot 2024-03-15 at 08 33 12" src="https://github.com/ddnexus/pagy/assets/3071529/f6d63d0f-88df-4e62-b246-7bb9f938a8a6">

If you're okay with this, I've applied a small change to return `null` for unavailable links in this pull request.

<img width="890" alt="Screenshot 2024-03-15 at 10 51 26" src="https://github.com/ddnexus/pagy/assets/3071529/b26f4401-db3b-4e2e-8dab-25c424c97b52">

---

<img width="890" alt="Screenshot 2024-03-15 at 10 51 43" src="https://github.com/ddnexus/pagy/assets/3071529/1817121c-3614-4491-96c5-0ea4a861b671">

---

<img width="890" alt="Screenshot 2024-03-15 at 10 52 01" src="https://github.com/ddnexus/pagy/assets/3071529/e0c8fe4a-43b0-43e8-ac56-3955db548289">

---

Let me know if you want me to change anything @ddnexus.