### PR TITLE
Don't change the state of a 'request' entity using while the '#pagy_url_for' method for calendar pagination

### DIFF
--- a/gem/lib/pagy/url_helpers.rb
+++ b/gem/lib/pagy/url_helpers.rb
@@ -8,7 +8,7 @@ class Pagy
     # For non-rack environments you can use the standalone extra
     def pagy_url_for(pagy, page, absolute: false, **_)
       vars         = pagy.vars
-      query_params = request.GET
+      query_params = request.GET.clone
       query_params.merge!(vars[:params].transform_keys(&:to_s)) if vars[:params].is_a?(Hash)
       pagy_set_query_params(page, vars, query_params)
       query_params = vars[:params].(query_params) if vars[:params].is_a?(Proc)


### PR DESCRIPTION
This PR fixes a bug that I faced trying to implement the calendar pagination.

## Simple explanation:
While doing the calendar pagination I'm getting the next error `expected :page >= 1; got "__pagy_page__"`

## The bug:
I think it was added to the `pagy_url_for` method in this [commit](https://github.com/ddnexus/pagy/commit/8d0b15239b64016c92f3bdc93025390f78c43ef1#diff-51b118db4a7362c98b661b01d662961ed6894e70d1f96ab1988e2ac5802fd423R11-R13), where we assign the `request.Get` object to the `query_params` variable and later change this object in the `pagy_set_query_params` method, so when after it we execute the `pagy_url_for` again the `request.Get` object is different and generates us broken URL.

## How I'm reproducing it in my Rails app
- add `gem 'pagy', '~> 8.1', '>= 8.1.2'` to my Gemfile (Rails project)
- `include Pagy::Frontend` in `ApplicationHelper`
-  `include Pagy::Backend` in my controller
- add `@calendar, @pagy, @meals = pagy_calendar(collection, year: { }, month: { }, day: { })` in my action (e.g. index)
- add several `pagy_nav...` in your view. For example `<%== pagy_nav(@calendar[:year]) %>` & `<%== pagy_nav(@calendar[:month]) %>`

## Check the bug in the [playground](https://ddnexus.github.io/pagy/playground/#4-calendar-app)
The bug is reproducible via Pagy Playground. Look at the images below as the proof:
1. Check generated links before the fix
2. Check generated links after the fix

<img width="600" alt="pagy calendar before fix" src="https://github.com/ddnexus/pagy/assets/43855653/ef7b19e6-3f3a-45aa-901b-88607aa3f204"> 

<img width="600" alt="pagy calendar after fix" src="https://github.com/ddnexus/pagy/assets/43855653/dcfa13b1-685d-4b18-b6a4-591b47ff05c6">