### PR TITLE
Add page_label translation for ko (closes #592)

### DIFF
--- a/gem/locales/ko.yml
+++ b/gem/locales/ko.yml
@@ -2,9 +2,7 @@
 ko:
   pagy:
     aria_label:
-      # please add a comment in the https://github.com/ddnexus/pagy/issues/592
-      # posting the translation of the following  "Page"/"Pages" with the plurals for this locale
-      nav: "Pages"
+      nav: "페이지"
       prev: "이전"
       next: "다음"
     prev: "&lt;"


### PR DESCRIPTION
I added the Korean translation, which sounds natural in this context if you use the same translation for "page" and "pages".