### PR TITLE
Docs: remove irrelevant characters

### DIFF
--- a/docs/api/pagy.md
+++ b/docs/api/pagy.md
@@ -196,7 +196,6 @@ Which means:
 - `in`, `from` and `to` of an empty page are all `0`
 - `prev` and `next` of a single page (not necessary an empty one) are both `nil` (i.e. there is no other page)
 
-===
 
 ## Exceptions
 


### PR DESCRIPTION
Remove the characters - looks like they were part of a mark down panel that got deleted. It is no longer needed.

![image](https://github.com/ddnexus/pagy/assets/15097447/50280b16-c636-45fe-9782-5f594380d424)
