### PR TITLE
fix slowness on last page (with ransack)

### DIFF
--- a/gem/lib/pagy/backend.rb
+++ b/gem/lib/pagy/backend.rb
@@ -38,7 +38,7 @@ class Pagy
     # Sub-method called only by #pagy: here for easy customization of record-extraction by overriding
     # You may need to override this method for collections without offset|limit
     def pagy_get_items(collection, pagy)
-      collection.offset(pagy.offset).limit(pagy.items)
+      collection.offset(pagy.offset).limit(pagy.page == pagy.last ? pagy.in : pagy.items)
     end
   end
 end


### PR DESCRIPTION
```ruby
#config/initializers/pagy.rb
Pagy::DEFAULT[:items] = 50
```

On my example, i have 14553 entries and i want the entries of the last page ( page=292)
```ruby
AwsEmail.where("created_at >= ? AND created_at <= ?", "2024-05-01 04:00:00", "2024-06-01 03:59:59").where(:event_type => "Delivery").count
# 14553
```

In my controller
```ruby
def emails
    puts("Start emails")
    t0                      = Time.now
    @search                 = AwsEmail.select(:id).ransack(params[:q])
    @search.sorts           = "id desc" if @search.sorts.empty?
    @search.event_type_eq   = "Delivery"
    @search.created_at_gteq = (Date.today.at_beginning_of_day - 1.day).beginning_of_month.beginning_of_day
    @search.created_at_lteq = (Date.today.at_beginning_of_month.next_month - 1.day).end_of_day
    @pagy, @emails          = pagy(@search.result(:distinct => true))
    puts("emails size => #{@emails.to_a.size}")
    puts(Time.now - t0)
  end
  ```



With the current gem version (LIMIT 50 OFFSET 14550),  it takes 60 seconds
```ruby
Start emails
AwsEmail Count (645.8ms)  SELECT COUNT(*) FROM (SELECT DISTINCT `aws_emails`.`id` FROM `aws_emails` WHERE (`aws_emails`.`event_type` = 'Delivery' AND `aws_emails`.`created_at` >= '2024-05-01 04:00:00' AND `aws_emails`.`created_at` <= '2024-06-01 03:59:59') ORDER BY `aws_emails`.`id` DESC) subquery_for_count
↳ app/controllers/dashboard_controller.rb:48:in `emails'
AwsEmail Load (60024.6ms)  SELECT DISTINCT `aws_emails`.`id` FROM `aws_emails` WHERE (`aws_emails`.`event_type` = 'Delivery' AND `aws_emails`.`created_at` >= '2024-05-01 04:00:00' AND `aws_emails`.`created_at` <= '2024-06-01 03:59:59') ORDER BY `aws_emails`.`id` DESC LIMIT 50 OFFSET 14550
↳ app/controllers/dashboard_controller.rb:49:in `emails'
emails size => 3
60.684757
```

With my pull request (LIMIT 3 OFFSET 14550) it takes 1 seconde
```ruby
Start emails
AwsEmail Count (536.9ms)  SELECT COUNT(*) FROM (SELECT DISTINCT `aws_emails`.`id` FROM `aws_emails` WHERE (`aws_emails`.`event_type` = 'Delivery' AND `aws_emails`.`created_at` >= '2024-05-01 04:00:00' AND `aws_emails`.`created_at` <= '2024-06-01 03:59:59') ORDER BY `aws_emails`.`id` DESC) subquery_for_count
↳ app/controllers/dashboard_controller.rb:48:in `emails'
AwsEmail Load (348.1ms)  SELECT DISTINCT `aws_emails`.`id` FROM `aws_emails` WHERE (`aws_emails`.`event_type` = 'Delivery' AND `aws_emails`.`created_at` >= '2024-05-01 04:00:00' AND `aws_emails`.`created_at` <= '2024-06-01 03:59:59') ORDER BY `aws_emails`.`id` DESC LIMIT 3 OFFSET 14550
↳ app/controllers/dashboard_controller.rb:49:in `emails'
emails size => 3
0.905018
```

I also noticed that when commenting @search.sorts, the intermediate select COUNT is different (without  `ORDER BY aws_emails.id DESC`) and  the query is fast with the current version of the gem.. but this order is important for the views.
so I don't know if this is another possible solution path...


```ruby

def emails
    puts("Start emails")
    t0                      = Time.now
    @search                 = AwsEmail.select(:id).ransack(params[:q])
    # @search.sorts           = "id desc" if @search.sorts.empty?
    @search.event_type_eq   = "Delivery"
    @search.created_at_gteq = (Date.today.at_beginning_of_day - 1.day).beginning_of_month.beginning_of_day
    @search.created_at_lteq = (Date.today.at_beginning_of_month.next_month - 1.day).end_of_day
    @pagy, @emails          = pagy(@search.result(:distinct => true))
    puts("emails size => #{@emails.to_a.size}")
    puts(Time.now - t0)
  end

Start emails
AwsEmail Count (391.2ms)  SELECT COUNT(*) FROM (SELECT DISTINCT `aws_emails`.`id` FROM `aws_emails` WHERE (`aws_emails`.`event_type` = 'Delivery' AND `aws_emails`.`created_at` >= '2024-05-01 04:00:00' AND `aws_emails`.`created_at` <= '2024-06-01 03:59:59')) subquery_for_count
↳ app/controllers/dashboard_controller.rb:48:in `emails'
AwsEmail Load (340.6ms)  SELECT DISTINCT `aws_emails`.`id` FROM `aws_emails` WHERE (`aws_emails`.`event_type` = 'Delivery' AND `aws_emails`.`created_at` >= '2024-05-01 04:00:00' AND `aws_emails`.`created_at` <= '2024-06-01 03:59:59') LIMIT 50 OFFSET 14550
↳ app/controllers/dashboard_controller.rb:49:in `emails'
emails size => 3
0.752417
```

