### PR TITLE
Typos adjusts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ If you upgrade from version `< 8.0.0` see the following:
 - HTML structure, classes and internal methods have been changed: they may break your views if you used custom stylesheets,
   templates or helper overrides. See the complete changes below if you notice any cosmetic changes or get some exception.
 - The `navs` and `support` extras has been merged into the new [pagy extra](https://ddnexus.github.io/pagy/docs/extras/pagy).
-  Search for `"extra/navs"` and
+  Search for `"extras/navs"` and
   `"extras/support"` and replace with `"extras/pagy"` (remove the duplicate if you used both)
 - The build path for javascript builders has been updated to the canonical paths for gems, and has moved from the `lib` to
   the gem root. Notice that the correct setup in `package json` was still wrongly wrapped in the `gem` dir for 8.0.0-8.0.1, and it
@@ -153,4 +153,4 @@ If you upgrade from version `< 8.0.0` see the following:
 - Docs Improvements
 - Better code issue template
 
-[LEGACY CHANGELOG >>>](CHANGELOG_LEGACY.md) 
+[LEGACY CHANGELOG >>>](CHANGELOG_LEGACY.md)

--- a/CHANGELOG_LEGACY.md
+++ b/CHANGELOG_LEGACY.md
@@ -1,10 +1,10 @@
----          
+---
 icon: versions-24
 layout: page
 visibility: hidden
 ---
 
-# LEGACY CHANGELOG 
+# LEGACY CHANGELOG
 
 ## Version 7.0.11
 
@@ -2417,7 +2417,7 @@ The pagy initializer has changed: please replace/update it: [pagy.rb](https://gi
 ### Breaking Changes
 
 - Extra are now integrated in Pagy. The `pagy-extras` gem has been discontinued: you should remove it and update your code as indicated [here](https://github.com/ddnexus/pagy-extras)
-- Pagy I18n has been refactored and it's simpler to use. The main change is that the `Pagy::I18N[:gem]` variable has been removed, so if you want to use the `I18n` gem in place of the internal Pagy implementation you need just to `require 'pagy/extra/i18n'` in your initializer. (see the [I18n doc](https://ddnexus.github.io/pagy/api/frontend.md#i18n))
+- Pagy I18n has been refactored and it's simpler to use. The main change is that the `Pagy::I18N[:gem]` variable has been removed, so if you want to use the `I18n` gem in place of the internal Pagy implementation you need just to `require 'pagy/extras/i18n'` in your initializer. (see the [I18n doc](https://ddnexus.github.io/pagy/api/frontend.md#i18n))
 - `pagy_url_for` now requires the pagy argument and it's called with 2 params: if you have overridden it, you should add the extra param.
 - `pagy_get_vars` now requires the vars argument and it's called with 2 params: if you have overridden it, you should add the extra param.
 - `pagy_array_get_vars` now requires the vars argument and it's called with 2 params: if you have overridden it, you should add the extra param.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 - **WARNING**: The `foundation`, `materialize`, `semantic` and `uikit` CSS extras
   have been discontinued and will be removed in v9 (See the [details](https://github.com/ddnexus/pagy/discussions/672#discussioncomment-9212328))
-- New [Pagy Playground](https://ddnexus.github.io/pagy/playground/) to showcase, clone and develop pagy APPs without any setup on 
+- New [Pagy Playground](https://ddnexus.github.io/pagy/playground/) to showcase, clone and develop pagy APPs without any setup on
   your side (try the [pagy demo](https://ddnexus.github.io/pagy/playground/#3-demo-app))
 - New `:max_pages` variable to limit the pagination regardless the actual count
 - Better frontend helpers
@@ -56,27 +56,27 @@ See the [Detailed Gems Comparison](http://ddnexus.github.io/pagination-compariso
 
 ## 🤩 It does it all. Better.
 
-- **It works in any environment**  
+- **It works in any environment**
   With Rack frameworks (Rails, Sinatra, Padrino, etc.) or in pure ruby without Rack
-- **It works with any collection**  
+- **It works with any collection**
   With any ORM, any DB, any search
   gem, [elasticsearch_rails](https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails), [meilisearch](https://ddnexus.github.io/pagy/docs/extras/meilisearch), [searchkick](https://ddnexus.github.io/pagy/docs/extras/searchkick), `ransack`,
   and just about any list, even if you cannot count it
-- **It supports all kinds of pagination**  
+- **It supports all kinds of pagination**
   [calendar](https://ddnexus.github.io/pagy/docs/extras/calendar "paginates by dates, rather than numbers"),
   [countless](https://ddnexus.github.io/pagy/docs/extras/countless "skips an extra 'count' query"),
   [geared](https://ddnexus.github.io/pagy/docs/extras/gearbox "varies the items fetched depending on the page number e.g. page 1: x items, but page 2: y items etc."),
-  [incremental, auto-incremental, infinite](https://ddnexus.github.io/pagy/docs/extras/pagy), 
+  [incremental, auto-incremental, infinite](https://ddnexus.github.io/pagy/docs/extras/pagy),
   [headers](https://ddnexus.github.io/pagy/docs/extras/headers "useful for API pagination"),
   [JSON](https://ddnexus.github.io/pagy/docs/extras/metadata "provides pagination metadata - especially useful with frameworks like Vue, React etc. and you want to render your own pagination links"),
-  [cursor](https://github.com/Uysim/pagy-cursor "Useful with large data sets, where performance becomes a concern (separate 
+  [cursor](https://github.com/Uysim/pagy-cursor "Useful with large data sets, where performance becomes a concern (separate
   repository)")
-- **It supports the most popular CSS Frameworks and APIs**  
-  [bootstrap](https://ddnexus.github.io/pagy/docs/extras/bootstrap), 
+- **It supports the most popular CSS Frameworks and APIs**
+  [bootstrap](https://ddnexus.github.io/pagy/docs/extras/bootstrap),
   [bulma](https://ddnexus.github.io/pagy/docs/extras/bulma),
   [tailwind](https://ddnexus.github.io/pagy/docs/extras/tailwind),
   [JSON:API](https://ddnexus.github.io/pagy/docs/extras/jsonapi/)
-- **It supports faster client-side rendering**  
+- **It supports faster client-side rendering**
   With classic or innovative UI components (see [Javascript Components](https://ddnexus.github.io/pagy/docs/api/javascript/)) or
   by
   serving [JSON](https://ddnexus.github.io/pagy/docs/extras/metadata) to your favorite Javascript framework

--- a/docs/extras/pagy.md
+++ b/docs/extras/pagy.md
@@ -80,7 +80,7 @@ part of the `pagy_nav` helper.
 
 Useful to build minimalistic helpers UIs that don't use nav bar links (e.g. `countless` extra).
 
-==- `pagy_next_a(pagy, text: pagy_t('pagy.next'), , aria_label: pagy_t('pagy.aria_label.prev))`
+==- `pagy_next_a(pagy, text: pagy_t('pagy.next'), aria_label: pagy_t('pagy.aria_label.prev))`
 
 Return the enabled/disabled next page anchor tag. It is the same next link string which is part of the
 `pagy_nav` helper.


### PR DESCRIPTION
Hi,

These are some small errors that I found while updating my application. If you need it to be in different PRs, I can do that too.

@ddnexus one question I got is how you are running the command to regenerate the Rematch files, looking in its documentation I found the command `rake test TESTOPTS=--rematch-rebuild`, however with this all the files were changed basically in the order in which tests are saved, would this be expected? Or is there some command that forces a certain ordering?

Complete command I used (it can even be mentioned in the contribution doc for those who don't "know" how to run it):
`docker run -it --rm --name pagy-script -v "$PWD":/usr/src/pagy -w /usr/src/pagy ruby:latest /bin/bash -c "bundle install && rake test TESTOPTS=--rematch-rebuild"`

Example of result with divergence:
![image](https://github.com/ddnexus/pagy/assets/17091381/fa1d504a-1686-46c5-a9f9-86625a59d0c4)
