### PR TITLE
Fix pluralization rule link on locale files

### DIFF
--- a/gem/locales/ar.yml
+++ b/gem/locales/ar.yml
@@ -1,4 +1,4 @@
-# :arabic pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :arabic pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 ar:
   pagy:
     aria_label:

--- a/gem/locales/be.yml
+++ b/gem/locales/be.yml
@@ -1,4 +1,4 @@
-# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 be:
   pagy:
     aria_label:

--- a/gem/locales/bg.yml
+++ b/gem/locales/bg.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 bg:
   pagy:
     aria_label:

--- a/gem/locales/bs.yml
+++ b/gem/locales/bs.yml
@@ -1,4 +1,4 @@
-# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 bs:
   pagy:
     aria_label:

--- a/gem/locales/ca.yml
+++ b/gem/locales/ca.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 ca:
   pagy:
     aria_label:

--- a/gem/locales/ckb.yml
+++ b/gem/locales/ckb.yml
@@ -1,4 +1,4 @@
-# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 
 ckb:
   pagy:

--- a/gem/locales/cs.yml
+++ b/gem/locales/cs.yml
@@ -1,4 +1,4 @@
-# :west_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :west_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 cs:
   pagy:
     aria_label:

--- a/gem/locales/da.yml
+++ b/gem/locales/da.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 da:
   pagy:
     aria_label:

--- a/gem/locales/de.yml
+++ b/gem/locales/de.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 de:
   pagy:
     aria_label:

--- a/gem/locales/en.yml
+++ b/gem/locales/en.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 en:
   pagy:
     aria_label:

--- a/gem/locales/es.yml
+++ b/gem/locales/es.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 es:
   pagy:
     aria_label:

--- a/gem/locales/fr.yml
+++ b/gem/locales/fr.yml
@@ -1,4 +1,4 @@
-# :one_upto_two_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_upto_two_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 fr:
   pagy:
     aria_label:

--- a/gem/locales/hr.yml
+++ b/gem/locales/hr.yml
@@ -1,4 +1,4 @@
-# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 hr:
   pagy:
     aria_label:

--- a/gem/locales/id.yml
+++ b/gem/locales/id.yml
@@ -1,4 +1,4 @@
-# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 id:
   pagy:
     aria_label:

--- a/gem/locales/it.yml
+++ b/gem/locales/it.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 it:
   pagy:
     aria_label:

--- a/gem/locales/ja.yml
+++ b/gem/locales/ja.yml
@@ -1,4 +1,4 @@
-# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 ja:
   pagy:
     aria_label:

--- a/gem/locales/km.yml
+++ b/gem/locales/km.yml
@@ -1,4 +1,4 @@
-# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 km:
   pagy:
     aria_label:

--- a/gem/locales/ko.yml
+++ b/gem/locales/ko.yml
@@ -1,4 +1,4 @@
-# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 ko:
   pagy:
     aria_label:

--- a/gem/locales/nb.yml
+++ b/gem/locales/nb.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 nb:
   pagy:
     aria_label:

--- a/gem/locales/nl.yml
+++ b/gem/locales/nl.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 nl:
   pagy:
     aria_label:

--- a/gem/locales/nn.yml
+++ b/gem/locales/nn.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 nn:
   pagy:
     aria_label:

--- a/gem/locales/pl.yml
+++ b/gem/locales/pl.yml
@@ -1,4 +1,4 @@
-# :polish pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :polish pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 pl:
   pagy:
     aria_label:

--- a/gem/locales/pt-BR.yml
+++ b/gem/locales/pt-BR.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 pt-BR:
   pagy:
     aria_label:

--- a/gem/locales/pt.yml
+++ b/gem/locales/pt.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 pt:
   pagy:
     aria_label:

--- a/gem/locales/ru.yml
+++ b/gem/locales/ru.yml
@@ -1,4 +1,4 @@
-# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 ru:
   pagy:
     aria_label:

--- a/gem/locales/sr.yml
+++ b/gem/locales/sr.yml
@@ -1,4 +1,4 @@
-# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 sr:
   pagy:
     aria_label:

--- a/gem/locales/sv-SE.yml
+++ b/gem/locales/sv-SE.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 sv-SE:
   pagy:
     aria_label:

--- a/gem/locales/sv.yml
+++ b/gem/locales/sv.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 sv:
   pagy:
     aria_label:

--- a/gem/locales/sw.yml
+++ b/gem/locales/sw.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 sw:
   pagy:
     # please add a comment in the https://github.com/ddnexus/pagy/issues/603

--- a/gem/locales/ta.yml
+++ b/gem/locales/ta.yml
@@ -1,4 +1,4 @@
-# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 ta:
   pagy:
     aria_label:

--- a/gem/locales/tr.yml
+++ b/gem/locales/tr.yml
@@ -1,4 +1,4 @@
-# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 tr:
   pagy:
     aria_label:

--- a/gem/locales/uk.yml
+++ b/gem/locales/uk.yml
@@ -1,4 +1,4 @@
-# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 uk:
   pagy:
     aria_label:

--- a/gem/locales/vi.yml
+++ b/gem/locales/vi.yml
@@ -1,4 +1,4 @@
-# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 vi:
   pagy:
     aria_label:

--- a/gem/locales/zh-CN.yml
+++ b/gem/locales/zh-CN.yml
@@ -1,4 +1,4 @@
-# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 zh-CN:
   pagy:
     aria_label:

--- a/gem/locales/zh-HK.yml
+++ b/gem/locales/zh-HK.yml
@@ -1,4 +1,4 @@
-# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 zh-HK:
   pagy:
     aria_label:

--- a/gem/locales/zh-TW.yml
+++ b/gem/locales/zh-TW.yml
@@ -1,4 +1,4 @@
-# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb)
+# :other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
 zh-TW:
   pagy:
     aria_label:

--- a/test/pagy/i18n_locales_test.rb
+++ b/test/pagy/i18n_locales_test.rb
@@ -28,7 +28,7 @@ describe 'pagy/locales' do
 
     it 'includes a comment with the pluralization rule and the i18n.rb reference' do
       _(rules).must_include rule, message
-      _(comment).must_match 'https://github.com/ddnexus/pagy/blob/master/lib/pagy/i18n.rb', message
+      _(comment).must_match 'https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb', message
     end
     it 'defines and matches the locale pluralization rule' do
       _(Pagy::I18n::P11n::LOCALE[locale]).must_equal Pagy::I18n::P11n::RULE[rule], message


### PR DESCRIPTION
Quick fix so links on locale files point to the correct location after the reorganizing the gem root dir.

Thank you.