### PR TITLE
fix: Prefix class names with Pagy module to prevent collisions

### DIFF
--- a/gem/apps/rails.ru
+++ b/gem/apps/rails.ru
@@ -91,8 +91,9 @@ class Comment < ActiveRecord::Base # :nodoc:
   belongs_to :post
 end # :nodoc:
 
-module Calendar # :nodoc:
-end # :nodoc:
+# Unused model, useful to test overriding conflicts
+module Calendar
+end
 
 # DB seed
 1.upto(11) do |pi|

--- a/gem/apps/rails.ru
+++ b/gem/apps/rails.ru
@@ -63,6 +63,7 @@ end
 require 'pagy/extras/pagy'
 require 'pagy/extras/limit'
 require 'pagy/extras/overflow'
+require 'pagy/extras/headers'
 Pagy::DEFAULT[:limit]    = 10
 Pagy::DEFAULT[:overflow] = :empty_page
 Pagy::DEFAULT.freeze
@@ -90,6 +91,9 @@ class Comment < ActiveRecord::Base # :nodoc:
   belongs_to :post
 end # :nodoc:
 
+module Calendar # :nodoc:
+end # :nodoc:
+
 # DB seed
 1.upto(11) do |pi|
   Post.create(title: "Post #{pi + 1}")
@@ -110,6 +114,7 @@ class CommentsController < ActionController::Base # :nodoc:
 
   def index
     @pagy, @comments = pagy(Comment.all)
+    pagy_headers_merge(@pagy)
     render inline: TEMPLATE
   end
 end

--- a/gem/lib/pagy/extras/headers.rb
+++ b/gem/lib/pagy/extras/headers.rb
@@ -25,9 +25,9 @@ class Pagy # :nodoc:
       pagy_link_header(pagy).tap do |hash|
         hash[headers[:page]]  = pagy.page.to_s if pagy.page && headers[:page]
         hash[headers[:limit]] = pagy.limit.to_s \
-            if headers[:limit] && !(defined?(Pagy::Calendar) && pagy.is_a?(Pagy::Calendar::Unit))
-        return hash if (defined?(Pagy::Countless) && pagy.is_a?(Pagy::Countless)) || \
-                       (defined?(Pagy::Keyset) && pagy.is_a?(Pagy::Keyset))
+            if headers[:limit] && !(defined?(::Pagy::Calendar) && pagy.is_a?(Calendar::Unit))
+        return hash if (defined?(::Pagy::Countless) && pagy.is_a?(Countless)) || \
+                       (defined?(::Pagy::Keyset) && pagy.is_a?(Keyset))
 
         hash[headers[:pages]] = pagy.last.to_s if headers[:pages]
         hash[headers[:count]] = pagy.count.to_s if pagy.count && headers[:count] # count may be nil with Calendar
@@ -36,7 +36,7 @@ class Pagy # :nodoc:
 
     def pagy_link_header(pagy)
       { 'link' => [].tap do |link|
-        if defined?(Pagy::Keyset) && pagy.is_a?(Pagy::Keyset)
+        if defined?(::Pagy::Keyset) && pagy.is_a?(Keyset)
           link << %(<#{pagy_url_for(pagy, nil, absolute: true)}>; rel="first")
           link << %(<#{pagy_url_for(pagy, pagy.next, absolute: true)}>; rel="next") if pagy.next
         else
@@ -45,7 +45,7 @@ class Pagy # :nodoc:
           link << %(<#{url_str.sub(PAGE_TOKEN, pagy.prev.to_s)}>; rel="prev") if pagy.prev
           link << %(<#{url_str.sub(PAGE_TOKEN, pagy.next.to_s)}>; rel="next") if pagy.next
           link << %(<#{url_str.sub(PAGE_TOKEN, pagy.last.to_s)}>; rel="last") \
-              unless defined?(Pagy::Countless) && pagy.is_a?(Pagy::Countless)
+              unless defined?(::Pagy::Countless) && pagy.is_a?(Countless)
         end
       end.join(', ') }
     end

--- a/gem/lib/pagy/extras/headers.rb
+++ b/gem/lib/pagy/extras/headers.rb
@@ -25,9 +25,9 @@ class Pagy # :nodoc:
       pagy_link_header(pagy).tap do |hash|
         hash[headers[:page]]  = pagy.page.to_s if pagy.page && headers[:page]
         hash[headers[:limit]] = pagy.limit.to_s \
-            if headers[:limit] && !(defined?(Calendar) && pagy.is_a?(Calendar::Unit))
-        return hash if (defined?(Countless) && pagy.is_a?(Countless)) || \
-                       (defined?(Keyset) && pagy.is_a?(Keyset))
+            if headers[:limit] && !(defined?(Pagy::Calendar) && pagy.is_a?(Pagy::Calendar::Unit))
+        return hash if (defined?(Pagy::Countless) && pagy.is_a?(Pagy::Countless)) || \
+                       (defined?(Pagy::Keyset) && pagy.is_a?(Pagy::Keyset))
 
         hash[headers[:pages]] = pagy.last.to_s if headers[:pages]
         hash[headers[:count]] = pagy.count.to_s if pagy.count && headers[:count] # count may be nil with Calendar
@@ -36,7 +36,7 @@ class Pagy # :nodoc:
 
     def pagy_link_header(pagy)
       { 'link' => [].tap do |link|
-        if defined?(Keyset) && pagy.is_a?(Keyset)
+        if defined?(Pagy::Keyset) && pagy.is_a?(Pagy::Keyset)
           link << %(<#{pagy_url_for(pagy, nil, absolute: true)}>; rel="first")
           link << %(<#{pagy_url_for(pagy, pagy.next, absolute: true)}>; rel="next") if pagy.next
         else
@@ -45,7 +45,7 @@ class Pagy # :nodoc:
           link << %(<#{url_str.sub(PAGE_TOKEN, pagy.prev.to_s)}>; rel="prev") if pagy.prev
           link << %(<#{url_str.sub(PAGE_TOKEN, pagy.next.to_s)}>; rel="next") if pagy.next
           link << %(<#{url_str.sub(PAGE_TOKEN, pagy.last.to_s)}>; rel="last") \
-              unless defined?(Countless) && pagy.is_a?(Countless)
+              unless defined?(Pagy::Countless) && pagy.is_a?(Pagy::Countless)
         end
       end.join(', ') }
     end

--- a/gem/lib/pagy/extras/i18n.rb
+++ b/gem/lib/pagy/extras/i18n.rb
@@ -19,7 +19,7 @@ class Pagy # :nodoc:
       end
     end
   end
-  Calendar::Unit.prepend I18nExtra::CalendarOverride if defined?(Calendar::Unit)
+  Calendar::Unit.prepend I18nExtra::CalendarOverride if defined?(::Pagy::Calendar::Unit)
 
   # Add the pagy locales to the I18n.load_path
   ::I18n.load_path += Dir[Pagy.root.join('locales', '*.yml')]

--- a/gem/lib/pagy/extras/js_tools.rb
+++ b/gem/lib/pagy/extras/js_tools.rb
@@ -44,7 +44,7 @@ class Pagy # :nodoc:
         end
       end
     end
-    Calendar::Unit.prepend CalendarOverride if defined?(Calendar::Unit)
+    Pagy::Calendar::Unit.prepend ::Pagy::JSTools::CalendarOverride if defined?(Pagy::Calendar::Unit)
 
     # Additions for the Frontend
     module FrontendAddOn

--- a/gem/lib/pagy/extras/js_tools.rb
+++ b/gem/lib/pagy/extras/js_tools.rb
@@ -44,11 +44,11 @@ class Pagy # :nodoc:
         end
       end
     end
-    Pagy::Calendar::Unit.prepend ::Pagy::JSTools::CalendarOverride if defined?(Pagy::Calendar::Unit)
+    Calendar::Unit.prepend CalendarOverride if defined?(::Pagy::Calendar::Unit)
 
     # Additions for the Frontend
     module FrontendAddOn
-      if defined?(Oj)
+      if defined?(::Oj)
         # Return a data tag with the base64 encoded JSON-serialized args generated with the faster oj gem
         # Base64 encoded JSON is smaller than HTML escaped JSON
         def pagy_data(pagy, *args)

--- a/gem/lib/pagy/extras/jsonapi.rb
+++ b/gem/lib/pagy/extras/jsonapi.rb
@@ -24,7 +24,7 @@ class Pagy # :nodoc:
 
       # Return the jsonapi links
       def pagy_jsonapi_links(pagy, **opts)
-        if defined?(Pagy::Keyset) && pagy.is_a?(Pagy::Keyset)
+        if defined?(::Pagy::Keyset) && pagy.is_a?(Keyset)
           { first: pagy_url_for(pagy, nil, **opts),
             last: nil,
             prev: nil,
@@ -67,7 +67,7 @@ class Pagy # :nodoc:
       end
     end
     # :nocov:
-    LimitExtra::BackendAddOn.prepend LimitExtraOverride if defined?(LimitExtra::BackendAddOn)
+    LimitExtra::BackendAddOn.prepend LimitExtraOverride if defined?(::Pagy::LimitExtra::BackendAddOn)
     # :nocov:
 
     # Module overriding UrlHelper

--- a/gem/lib/pagy/extras/metadata.rb
+++ b/gem/lib/pagy/extras/metadata.rb
@@ -17,7 +17,7 @@ class Pagy # :nodoc:
     def pagy_metadata(pagy, absolute: nil)
       scaffold_url = pagy_url_for(pagy, PAGE_TOKEN, absolute:)
       {}.tap do |metadata|
-        keys = if defined?(Pagy::Calendar::Unit) && pagy.is_a?(Pagy::Calendar::Unit)
+        keys = if defined?(::Pagy::Calendar::Unit) && pagy.is_a?(Calendar::Unit)
                  pagy.vars[:metadata] - %i[count limit]
                else
                  pagy.vars[:metadata]

--- a/gem/lib/pagy/extras/metadata.rb
+++ b/gem/lib/pagy/extras/metadata.rb
@@ -17,7 +17,7 @@ class Pagy # :nodoc:
     def pagy_metadata(pagy, absolute: nil)
       scaffold_url = pagy_url_for(pagy, PAGE_TOKEN, absolute:)
       {}.tap do |metadata|
-        keys = if defined?(Calendar::Unit) && pagy.is_a?(Calendar::Unit)
+        keys = if defined?(Pagy::Calendar::Unit) && pagy.is_a?(Pagy::Calendar::Unit)
                  pagy.vars[:metadata] - %i[count limit]
                else
                  pagy.vars[:metadata]

--- a/gem/lib/pagy/extras/overflow.rb
+++ b/gem/lib/pagy/extras/overflow.rb
@@ -28,8 +28,8 @@ class Pagy # :nodoc:
           @vars[:page] = requested_page                # restore the requested page
         when :empty_page
           @offset = @limit = @in = @from = @to = 0     # vars relative to the actual page
-          if defined?(Calendar::Unit) \
-              && is_a?(Calendar::Unit)                 # only for Calendar::Units instances
+          if defined?(Pagy::Calendar::Unit) \
+              && is_a?(Pagy::Calendar::Unit)           # only for Calendar::Units instances
             edge = @order == :asc ? @final : @initial  # get the edge of the overflow side (neat, but any time would do)
             @from = @to = edge                         # set both to the edge utc time (a >=&&< query will get no records)
           end
@@ -52,7 +52,7 @@ class Pagy # :nodoc:
       end
     end
     Pagy.prepend PagyOverride
-    Pagy::Calendar::Unit.prepend PagyOverride if defined?(Calendar::Unit)
+    Pagy::Calendar::Unit.prepend PagyOverride if defined?(Pagy::Calendar::Unit)
 
     # Support for Pagy::Countless class
     module CountlessOverride
@@ -75,7 +75,7 @@ class Pagy # :nodoc:
       end
     end
     # :nocov:
-    Pagy::Countless.prepend CountlessOverride if defined?(Countless)
+    Pagy::Countless.prepend CountlessOverride if defined?(Pagy::Countless)
     # :nocov:
   end
 end

--- a/gem/lib/pagy/extras/overflow.rb
+++ b/gem/lib/pagy/extras/overflow.rb
@@ -28,8 +28,8 @@ class Pagy # :nodoc:
           @vars[:page] = requested_page                # restore the requested page
         when :empty_page
           @offset = @limit = @in = @from = @to = 0     # vars relative to the actual page
-          if defined?(Pagy::Calendar::Unit) \
-              && is_a?(Pagy::Calendar::Unit)           # only for Calendar::Units instances
+          if defined?(::Pagy::Calendar::Unit) \
+              && is_a?(Calendar::Unit)                 # only for Calendar::Units instances
             edge = @order == :asc ? @final : @initial  # get the edge of the overflow side (neat, but any time would do)
             @from = @to = edge                         # set both to the edge utc time (a >=&&< query will get no records)
           end
@@ -52,7 +52,7 @@ class Pagy # :nodoc:
       end
     end
     Pagy.prepend PagyOverride
-    Pagy::Calendar::Unit.prepend PagyOverride if defined?(Pagy::Calendar::Unit)
+    Pagy::Calendar::Unit.prepend PagyOverride if defined?(::Pagy::Calendar::Unit)
 
     # Support for Pagy::Countless class
     module CountlessOverride
@@ -75,7 +75,7 @@ class Pagy # :nodoc:
       end
     end
     # :nocov:
-    Pagy::Countless.prepend CountlessOverride if defined?(Pagy::Countless)
+    Pagy::Countless.prepend CountlessOverride if defined?(::Pagy::Countless)
     # :nocov:
   end
 end


### PR DESCRIPTION
This commit updates the code to prefix certain class names with the Pagy module name. The change is necessary to prevent potential collisions with class names defined in Rails applications.

These adjustments ensure that the Pagy pagination library operates correctly without interfering with other classes that might exist within the application namespace. The revised code now properly isolates Pagy-specific classes, enhancing compatibility and stability