### PR TITLE
Fix missing `Pagy::` prefix in Searchkick section of config

### DIFF
--- a/gem/config/pagy.rb
+++ b/gem/config/pagy.rb
@@ -104,7 +104,7 @@
 # See https://ddnexus.github.io/pagy/docs/extras/searchkick
 # Default :pagy_search method: change only if you use also
 # the elasticsearch_rails or meilisearch extra that defines the same
-# DEFAULT[:searchkick_pagy_search] = :pagy_search
+# Pagy::DEFAULT[:searchkick_pagy_search] = :pagy_search
 # Default original :search method called internally to do the actual search
 # Pagy::DEFAULT[:searchkick_search] = :search
 # require 'pagy/extras/searchkick'


### PR DESCRIPTION
Hey, thanks so much for Pagy, it looks awesome!

I noticed one minor typo in the `pagy.rb` file when setting it up to work with Searchkick - specifically, one of the `DEFAULT` values which is set is not prefixed with `Pagy::`. Check out the diff :)

Hope it helps and keep up the great work!