### PR TITLE
Fix/Set freeze flag to false

### DIFF
--- a/gem/lib/pagy/url_helpers.rb
+++ b/gem/lib/pagy/url_helpers.rb
@@ -8,7 +8,7 @@ class Pagy
     # For non-rack environments you can use the standalone extra
     def pagy_url_for(pagy, page, absolute: false, fragment: nil, **_)
       vars         = pagy.vars
-      query_params = request.GET.clone
+      query_params = request.GET.clone(freeze: false)
       query_params.merge!(vars[:params].transform_keys(&:to_s)) if vars[:params].is_a?(Hash)
       pagy_set_query_params(page, vars, query_params)
       query_params = vars[:params].(query_params) if vars[:params].is_a?(Proc)


### PR DESCRIPTION
This PR addresses an issue where the `pagy_url_for` method was attempting to modify a frozen `ActiveSupport::HashWithIndifferentAccess` object, leading to a FrozenError due to the immutability of the hash. The `pagy_set_query_params` method modifies the `query_params` hash, which caused issues when the hash was frozen.

According to the docs of [Kernel#clone](https://ruby-doc.org/core-3.0.2/Kernel.html#method-i-clone) method it returns frozen object if it was frozen.
