### PR TITLE
Update `Pagy:: Backend` comment

### DIFF
--- a/gem/lib/pagy/backend.rb
+++ b/gem/lib/pagy/backend.rb
@@ -1,5 +1,6 @@
 # See Pagy::Backend API documentation: https://ddnexus.github.io/pagy/docs/api/backend
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 class Pagy
   # Define a few generic methods to paginate a collection out of the box,

--- a/gem/lib/pagy/backend.rb
+++ b/gem/lib/pagy/backend.rb
@@ -3,7 +3,7 @@
 
 class Pagy
   # Define a few generic methods to paginate a collection out of the box,
-  # or any collection by overriding pagy_get_items and/or pagy_get_vars in your controller
+  # or any collection by overriding any of the `pagy_get_` methods in your controller.
   # See also the extras if you need specialized methods to paginate Arrays or other collections
   module Backend
     private

--- a/gem/lib/pagy/backend.rb
+++ b/gem/lib/pagy/backend.rb
@@ -3,7 +3,7 @@
 
 class Pagy
   # Define a few generic methods to paginate a collection out of the box,
-  # or any collection by overriding any of the `pagy_get_` methods in your controller.
+  # or any collection by overriding any of the `pagy_get_*` methods in your controller.
   # See also the extras if you need specialized methods to paginate Arrays or other collections
   module Backend
     private

--- a/gem/lib/pagy/extras/arel.rb
+++ b/gem/lib/pagy/extras/arel.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/arel
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 class Pagy # :nodoc:
   # Better performance of grouped ActiveRecord collections

--- a/gem/lib/pagy/extras/array.rb
+++ b/gem/lib/pagy/extras/array.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/array
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 class Pagy # :nodoc:
   # Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding

--- a/gem/lib/pagy/extras/calendar.rb
+++ b/gem/lib/pagy/extras/calendar.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/calendar
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 require_relative '../calendar'
 

--- a/gem/lib/pagy/extras/countless.rb
+++ b/gem/lib/pagy/extras/countless.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/countless
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 require_relative '../countless'
 

--- a/gem/lib/pagy/extras/elasticsearch_rails.rb
+++ b/gem/lib/pagy/extras/elasticsearch_rails.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/elasticsearch_rails
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 class Pagy # :nodoc:
   DEFAULT[:elasticsearch_rails_search]      ||= :search

--- a/gem/lib/pagy/extras/headers.rb
+++ b/gem/lib/pagy/extras/headers.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/headers
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 require_relative '../url_helpers'
 

--- a/gem/lib/pagy/extras/jsonapi.rb
+++ b/gem/lib/pagy/extras/jsonapi.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/jsonapi
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 require_relative '../url_helpers'
 

--- a/gem/lib/pagy/extras/keyset.rb
+++ b/gem/lib/pagy/extras/keyset.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/keyset
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 require_relative '../keyset'
 

--- a/gem/lib/pagy/extras/limit.rb
+++ b/gem/lib/pagy/extras/limit.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/limit
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 require_relative 'js_tools'
 

--- a/gem/lib/pagy/extras/meilisearch.rb
+++ b/gem/lib/pagy/extras/meilisearch.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/meilisearch
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 class Pagy # :nodoc:
   DEFAULT[:meilisearch_search]      ||= :ms_search

--- a/gem/lib/pagy/extras/metadata.rb
+++ b/gem/lib/pagy/extras/metadata.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/metadata
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 require_relative '../url_helpers'
 

--- a/gem/lib/pagy/extras/searchkick.rb
+++ b/gem/lib/pagy/extras/searchkick.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/searchkick
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 class Pagy # :nodoc:
   DEFAULT[:searchkick_search]      ||= :search

--- a/gem/lib/pagy/extras/size.rb
+++ b/gem/lib/pagy/extras/size.rb
@@ -1,5 +1,6 @@
 # See the Pagy documentation: https://ddnexus.github.io/pagy/docs/extras/size
 # frozen_string_literal: true
+# You can override any of the `pagy_*` methods in your controller.
 
 class Pagy # :nodoc:
   # Implement the legacy bar using the array size.


### PR DESCRIPTION
Hi 👋

I've noticed that the overriding  of `pagy_get_vars` stopped working after the 9.0.0 upgrade.     
It seems this method was removed during [this refactoring](https://github.com/ddnexus/pagy/commit/26b8117fe547f9ec5dfd75b248fbe31910d77fc1#diff-e6c288388e84855ee6d63cfbcc7cb692986aa68e7683af84ad98eed4cb95eb93R55).     

In my use case, I was able to switch to overriding `pagy_get_count` instead.

I've updated the comment to reflect this change.