### PR TITLE
Chore: add test for locales - to find problematic keys

### DIFF
--- a/gem/locales/sw.yml
+++ b/gem/locales/sw.yml
@@ -3,6 +3,8 @@ sw:
   pagy:
     # please add a comment in the https://github.com/ddnexus/pagy/issues/603
     # posting the translation of the following  "Page"/"Pages" with the plurals for this locale
+    # Please change the final test in 18n_loacles_test.rb to remove the sw.yml exclusion
+    # after you make these changes.
     aria_label:
       nav: "Pages"
 #        one: ""

--- a/gem/locales/ta.yml
+++ b/gem/locales/ta.yml
@@ -4,6 +4,8 @@ ta:
     aria_label:
       # please add a comment in the https://github.com/ddnexus/pagy/issues/604
       # posting the translation of the following  "Page"/"Pages" with the plurals for this locale
+      # Please change the final test in 18n_loacles_test.rb to remove the ta.yml exclusion
+      # after you make these changes.
       nav: "Pages"
 #        one: ""
 #        other: ""

--- a/test/pagy/i18n_locales_test.rb
+++ b/test/pagy/i18n_locales_test.rb
@@ -21,10 +21,11 @@ describe 'pagy/locales' do
   Pagy.root.join('locales').each_child do |f|
     next unless f.extname == '.yml'
 
-    message = "locale file #{f}"
-    locale  = f.basename.to_s[0..-5]                 # e.g. de
-    comment = f.readlines.first.to_s.strip           # e.g. :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
-    rule    = comment.to_s.split[1][1..].to_s.to_sym # e.g. one_other
+    message       = "locale file #{f}"
+    locale        = f.basename.to_s[0..-5]                 # e.g. de
+    comment       = f.readlines.first.to_s.strip           # e.g. :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
+    rule          = comment.to_s.split[1][1..].to_s.to_sym # e.g. one_other
+    language_yml  = YAML.safe_load(f.read)
 
     it 'includes a comment with the pluralization rule and the i18n.rb reference' do
       _(rules).must_include rule, message
@@ -34,7 +35,6 @@ describe 'pagy/locales' do
       _(Pagy::I18n::P11n::LOCALE[locale]).must_equal Pagy::I18n::P11n::RULE[rule], message
     end
     it 'pluralizes item_name according to the rule' do
-      language_yml      = YAML.safe_load(f.read)
       item_name = language_yml[locale]['pagy']['item_name']
       case item_name
       when String
@@ -48,7 +48,6 @@ describe 'pagy/locales' do
     it "ensures #{locale}.yml rules (#{rule}) have the correct aria_label,nav and item_name keys applied" do
       skip if %w[ta sw].include?(locale) # ta.yml and sw.yml do not have the requisite keys yet
 
-      language_yml = YAML.safe_load(f.read)
       pluralizations = counts[rule]
 
       if rule == :other

--- a/test/pagy/i18n_locales_test.rb
+++ b/test/pagy/i18n_locales_test.rb
@@ -53,7 +53,7 @@ describe 'pagy/locales' do
 
       if rule == :other
         # For the :other rules, we should not have any keys under the
-        # ['pagy']['item_name'] and ['pagy']['aria_label'] hierarchies.
+        # ['pagy']['item_name'] and ['pagy']['aria_label']['nav'] hierarchies.
         # We should just have a String.
         _(hash[locale]['pagy']['item_name']).must_be_instance_of(String)
         _(hash[locale]['pagy']['aria_label']['nav']).must_be_instance_of(String)

--- a/test/pagy/i18n_locales_test.rb
+++ b/test/pagy/i18n_locales_test.rb
@@ -34,8 +34,8 @@ describe 'pagy/locales' do
       _(Pagy::I18n::P11n::LOCALE[locale]).must_equal Pagy::I18n::P11n::RULE[rule], message
     end
     it 'pluralizes item_name according to the rule' do
-      hash      = YAML.safe_load(f.read)
-      item_name = hash[locale]['pagy']['item_name']
+      language_yml      = YAML.safe_load(f.read)
+      item_name = language_yml[locale]['pagy']['item_name']
       case item_name
       when String
         _(rule).must_equal :other
@@ -48,18 +48,18 @@ describe 'pagy/locales' do
     it "ensures #{locale}.yml rules (#{rule}) have the correct aria_label,nav and item_name keys applied" do
       skip if %w[ta sw].include?(locale) # ta.yml and sw.yml do not have the requisite keys yet
 
-      hash = YAML.safe_load(f.read)
+      language_yml = YAML.safe_load(f.read)
       pluralizations = counts[rule]
 
       if rule == :other
         # For the :other rules, we should not have any keys under the
         # ['pagy']['item_name'] and ['pagy']['aria_label']['nav'] hierarchies.
         # We should just have a String.
-        _(hash[locale]['pagy']['item_name']).must_be_instance_of(String)
-        _(hash[locale]['pagy']['aria_label']['nav']).must_be_instance_of(String)
+        _(language_yml[locale]['pagy']['item_name']).must_be_instance_of(String)
+        _(language_yml[locale]['pagy']['aria_label']['nav']).must_be_instance_of(String)
       else
-        _(hash[locale]['pagy']['item_name'].keys.sort).must_equal pluralizations.sort, "In #{message} - check that ['pagy']['item_name'] does not have keys inconsistent with #{rule}"
-        _(hash[locale]['pagy']['aria_label']['nav'].keys.sort).must_equal pluralizations.sort, "In #{message} - check that ['pagy']['aria_label']['nav'] does not have keys inconsistent with #{rule}"
+        _(language_yml[locale]['pagy']['item_name'].keys.sort).must_equal pluralizations.sort, "In #{message} - check that ['pagy']['item_name'] does not have keys inconsistent with #{rule}"
+        _(language_yml[locale]['pagy']['aria_label']['nav'].keys.sort).must_equal pluralizations.sort, "In #{message} - check that ['pagy']['aria_label']['nav'] does not have keys inconsistent with #{rule}"
       end
     end
   end

--- a/test/pagy/i18n_locales_test.rb
+++ b/test/pagy/i18n_locales_test.rb
@@ -45,7 +45,7 @@ describe 'pagy/locales' do
         raise StandardError, "item_name must be Hash or String"
       end
     end
-    it "ensures #{locale}.yml rules (#{rule}) have the correct aria_label,nav and item_name keys applied" do
+    it "ensures #{locale}.yml has the correct aria_label,nav and item_name keys per the declared (#{rule}) rule" do
       skip if %w[ta sw].include?(locale) # ta.yml and sw.yml do not have the requisite keys yet
 
       pluralizations = counts[rule]

--- a/test/pagy/i18n_locales_test.rb
+++ b/test/pagy/i18n_locales_test.rb
@@ -22,9 +22,9 @@ describe 'pagy/locales' do
     next unless f.extname == '.yml'
 
     message = "locale file #{f}"
-    locale  = f.basename.to_s[0..-5]
-    comment = f.readlines.first.to_s.strip
-    rule    = comment.to_s.split[1][1..].to_s.to_sym
+    locale  = f.basename.to_s[0..-5]                 # e.g. de
+    comment = f.readlines.first.to_s.strip           # e.g. :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
+    rule    = comment.to_s.split[1][1..].to_s.to_sym # e.g. one_other 
 
     it 'includes a comment with the pluralization rule and the i18n.rb reference' do
       _(rules).must_include rule, message
@@ -44,6 +44,23 @@ describe 'pagy/locales' do
       else
         raise StandardError, "item_name must be Hash or String"
       end
+    end
+    it "ensures #{locale}.yml rules (#{rule}) have the correct aria_label,nav and item_name keys applied" do
+        skip if %w(ta sw).include?(locale) # ta.yml and sw.yml do not have the requisite keys yet
+
+        hash = YAML.safe_load(f.read)
+        pluralizations = counts[rule]
+
+        if rule == :other
+           # For the :other rules, we should not have any keys under the
+           # ['pagy']['item_name'] and ['pagy']['aria_label'] hierarchies.
+           # We should just have a String.
+          _(hash[locale]['pagy']['item_name']).must_be_instance_of(String)
+          _(hash[locale]['pagy']['aria_label']['nav']).must_be_instance_of(String)
+        else
+          _(hash[locale]['pagy']['item_name'].keys.sort).must_equal pluralizations.sort, "In #{message} - check that ['pagy']['item_name'] does not have keys inconsistent with #{rule}"
+          _(hash[locale]['pagy']['aria_label']['nav'].keys.sort).must_equal pluralizations.sort, "In #{message} - check that ['pagy']['aria_label']['nav'] does not have keys inconsistent with #{rule}"
+        end
     end
   end
 end

--- a/test/pagy/i18n_locales_test.rb
+++ b/test/pagy/i18n_locales_test.rb
@@ -24,7 +24,7 @@ describe 'pagy/locales' do
     message = "locale file #{f}"
     locale  = f.basename.to_s[0..-5]                 # e.g. de
     comment = f.readlines.first.to_s.strip           # e.g. :one_other pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
-    rule    = comment.to_s.split[1][1..].to_s.to_sym # e.g. one_other 
+    rule    = comment.to_s.split[1][1..].to_s.to_sym # e.g. one_other
 
     it 'includes a comment with the pluralization rule and the i18n.rb reference' do
       _(rules).must_include rule, message
@@ -46,21 +46,21 @@ describe 'pagy/locales' do
       end
     end
     it "ensures #{locale}.yml rules (#{rule}) have the correct aria_label,nav and item_name keys applied" do
-        skip if %w(ta sw).include?(locale) # ta.yml and sw.yml do not have the requisite keys yet
+      skip if %w[ta sw].include?(locale) # ta.yml and sw.yml do not have the requisite keys yet
 
-        hash = YAML.safe_load(f.read)
-        pluralizations = counts[rule]
+      hash = YAML.safe_load(f.read)
+      pluralizations = counts[rule]
 
-        if rule == :other
-           # For the :other rules, we should not have any keys under the
-           # ['pagy']['item_name'] and ['pagy']['aria_label'] hierarchies.
-           # We should just have a String.
-          _(hash[locale]['pagy']['item_name']).must_be_instance_of(String)
-          _(hash[locale]['pagy']['aria_label']['nav']).must_be_instance_of(String)
-        else
-          _(hash[locale]['pagy']['item_name'].keys.sort).must_equal pluralizations.sort, "In #{message} - check that ['pagy']['item_name'] does not have keys inconsistent with #{rule}"
-          _(hash[locale]['pagy']['aria_label']['nav'].keys.sort).must_equal pluralizations.sort, "In #{message} - check that ['pagy']['aria_label']['nav'] does not have keys inconsistent with #{rule}"
-        end
+      if rule == :other
+        # For the :other rules, we should not have any keys under the
+        # ['pagy']['item_name'] and ['pagy']['aria_label'] hierarchies.
+        # We should just have a String.
+        _(hash[locale]['pagy']['item_name']).must_be_instance_of(String)
+        _(hash[locale]['pagy']['aria_label']['nav']).must_be_instance_of(String)
+      else
+        _(hash[locale]['pagy']['item_name'].keys.sort).must_equal pluralizations.sort, "In #{message} - check that ['pagy']['item_name'] does not have keys inconsistent with #{rule}"
+        _(hash[locale]['pagy']['aria_label']['nav'].keys.sort).must_equal pluralizations.sort, "In #{message} - check that ['pagy']['aria_label']['nav'] does not have keys inconsistent with #{rule}"
+      end
     end
   end
 end


### PR DESCRIPTION
### Why this PR?

* When users make submissions for locales, they often cut and paste from other locales, and incorrectly apply the rules.
* It is currently quite cumbersome to manually check whether the rules have been currectly applied. I would prefer if there was a test to help aid in the discovery of discrepancies.

For example, I might declare that the Klingon language has the e.g. :east_slavic pluralization rule, but I might incorrectly label as per : other pluralization rule: e.g.

```yml
# :east_slavic pluralization (see https://github.com/ddnexus/pagy/blob/master/gem/lib/pagy/i18n.rb)
klingon:
  pagy:
    aria_label:
      nav: 
        wrong_key: "this key applies to another locale"
        wrong_key_2:  "this key applies to another locale"

# all of the above is a cut-and-paste from another locale
# it does not apply here
```
Right now you have to manually check. But these test will help capture such discrepancies, and tell you what should be applied instead.

### ISSUES with the PR

- `ta.yml` and `swa.yml` are excluded from the checks
- it will not check if the .yml keys have been misapplied to the wrong label. in other words, manual checking is still required.