### PR TITLE
Docs: fix missing separator in setup.md

### DIFF
--- a/docs/api/javascript/setup.md
+++ b/docs/api/javascript/setup.md
@@ -169,6 +169,8 @@ module.exports = {
 }
 ```
 
++++
+
 #### Non-Rails apps
 
 * Just ensure `Pagy.root.join('javascripts', 'pagy.js')` is served with the page.


### PR DESCRIPTION
The "Initialize Pagy" part is currently squished together with the "Builder" menu on the doc website.