### PR TITLE
Fix method visibility in JsonApiExtra

### DIFF
--- a/gem/lib/pagy/extras/jsonapi.rb
+++ b/gem/lib/pagy/extras/jsonapi.rb
@@ -18,9 +18,11 @@ class Pagy # :nodoc:
 
     # Module overriding Backend
     module BackendOverride
-      private
-
       include UrlHelpers
+
+      private(*UrlHelpers.instance_methods)
+
+      private
 
       # Return the jsonapi links
       def pagy_jsonapi_links(pagy, **opts)


### PR DESCRIPTION
If you load the Jsonapi extra and include `Pagy::Backend` in a controller then `pagy_url_for` and `pagy_set_query_params` will be added as public methods. Only the controller methods that are mapped to routes should be public.