### PR TITLE
Support JSON:API Parsing in `Trim`

### DIFF
--- a/gem/lib/pagy/extras/trim.rb
+++ b/gem/lib/pagy/extras/trim.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 class Pagy # :nodoc:
-  DEFAULT[:trim_extra] = true   # extra enabled by default
+  DEFAULT[:trim_extra] = true # extra enabled by default
 
   # Remove the page=1 param from the first page link
   module TrimExtra
@@ -22,7 +22,15 @@ class Pagy # :nodoc:
 
     # Remove the :page_param param from the first page anchor
     def pagy_trim(pagy, a)
-      a.sub!(/[?&]#{pagy.vars[:page_param]}=1\b(?!&)|\b#{pagy.vars[:page_param]}=1&/, '')
+      page_param = pagy.vars[:page_param]
+      pattern = if pagy.vars[:jsonapi]
+                  # Handle both URL-encoded (%5B, %5D) and non-encoded formats for robustness
+                  # Match both page[param]=1 and page%5Bparam%5D=1 formats
+                  /[?&]page(?:%5B|\[)#{page_param}(?:%5D|\])=1\b(?!&)|\bpage(?:%5B|\[)#{page_param}(?:%5D|\])=1&/
+                else
+                  /[?&]#{page_param}=1\b(?!&)|\b#{page_param}=1&/
+                end
+      a.sub!(pattern, '')
     end
   end
   Frontend.prepend TrimExtra

--- a/test/pagy/extras/trim_test.rb
+++ b/test/pagy/extras/trim_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../../test_helper'
 require 'pagy/extras/trim'
-
+require 'pagy/extras/jsonapi'
 require_relative '../../mock_helpers/app'
 
 describe 'pagy/extras/trim' do
@@ -28,13 +28,47 @@ describe 'pagy/extras/trim' do
         page = params[:page]
         app  = MockApp.new(params: params)
 
-        pagy = Pagy.new(count: 1000, page: page)
+        pagy = Pagy.new(count: 1000, page: page, jsonapi: false)
         a    = app.pagy_anchor(pagy)
         _(a.(page)).must_include(%(<a href="/foo#{trimmed}"))
 
-        pagy = Pagy.new(count: 1000, page: page, trim_extra: false)
+        pagy = Pagy.new(count: 1000, page: page, jsonapi: false, trim_extra: false)
         a    = app.pagy_anchor(pagy)
         _(a.(page)).must_include(%(<a href="/foo#{not_trimmed}"))
+      end
+    end
+
+    describe 'when jsonapi is enabled' do
+      it 'returns trimmed or not trimmed links' do
+        [ # first page
+          [{ page: { page: 1 } }, '?page%5Bpage%5D=1', ''], # only param
+          [{ page: { page: '1' } }, '?page%5Bpage%5D=1', ''], # only param
+          [{ page: { page: 1 }, b: 2 }, '?page%5Bpage%5D=1&b=2', '?b=2'], # first param
+          [{ a: 1, page: { page: 1 }, b: 2 }, '?a=1&page%5Bpage%5D=1&b=2', '?a=1&b=2'], # middle param
+          [{ a: 1, page: { page: 1 } }, '?a=1&page%5Bpage%5D=1', '?a=1'], # last param
+          # first page with similar key (my_page)
+          [{ my_page: 1, page: { page: 1 } }, '?my_page=1&page%5Bpage%5D=1', '?my_page=1'], # similar first param
+          [{ a: 1, my_page: 1, page: { page: 1 } }, '?a=1&my_page=1&page%5Bpage%5D=1', '?a=1&my_page=1'], # similar middle param
+          [{ a: 1, page: { page: 1 }, my_page: 1 }, '?a=1&page%5Bpage%5D=1&my_page=1', '?a=1&my_page=1'], # similar last param
+          # no first page but similar value (11)
+          [{ page: { page: 11 } }, '?page%5Bpage%5D=11', '?page%5Bpage%5D=11'], # only param
+          [{ page: { page: 11 }, b: 2 }, '?page%5Bpage%5D=11&b=2', '?page%5Bpage%5D=11&b=2'], # first param
+          [{ a: 1, page: { page: 11 }, b: 2 }, '?a=1&page%5Bpage%5D=11&b=2', '?a=1&page%5Bpage%5D=11&b=2'], # middle param
+          [{ a: 1, page: { page: 11 } }, '?a=1&page%5Bpage%5D=11', '?a=1&page%5Bpage%5D=11'] # last param
+        ].each do |args|
+          params, not_trimmed, trimmed = args
+
+          page = params[:page][:page]
+          app = MockApp.new(params: params)
+
+          pagy = Pagy.new(count: 1000, page: page, jsonapi: true)
+          a = app.pagy_anchor(pagy)
+          _(a.(page)).must_include(%(<a href="/foo#{trimmed}"))
+
+          pagy = Pagy.new(count: 1000, page: page, jsonapi: true, trim_extra: false)
+          a = app.pagy_anchor(pagy)
+          _(a.(page)).must_include(%(<a href="/foo#{not_trimmed}"))
+        end
       end
     end
   end


### PR DESCRIPTION
This is a V1 draft just to show the concept I alluded to in #773.

I am not sure about the consistent availability of `pagy.vars[:jsonapi]` across requests. However, I hope this is somewhat helpful as an initial parsing testing implementation, in case this avenue is pursued

*I'm not sure about preferred comment/test structure either*

As a demo of the changes, here is the demo test app setup as described in #773, showing the implementation working

https://github.com/user-attachments/assets/f7483827-42be-4bae-83e4-e2b426e081d3

