### PR TITLE
fix column names quotation in keyset

### DIFF
--- a/gem/lib/pagy/keyset.rb
+++ b/gem/lib/pagy/keyset.rb
@@ -90,10 +90,10 @@ class Pagy
     # with a set like Pet.order(:animal, :name, :id) it returns the following string:
     # ( "pets"."animal", "pets"."name", "pets"."id" ) > ( :animal, :name, :id )
     def filter_newest_query
-      operator   = { asc: '>', desc: '<' }
+      operator = { asc: '>', desc: '<' }
       directions = @keyset.values
-      table      = @set.model.table_name
-      name       = @keyset.to_h { |column| [column, %("#{table}"."#{column}")] }
+      name = quoted_identifiers(@set.model.table_name)
+
       if @vars[:tuple_comparison] && (directions.all?(:asc) || directions.all?(:desc))
         placeholders = @keyset.keys.map { |column| ":#{column}" }.join(', ')
         "( #{name.values.join(', ')} ) #{operator[directions.first]} ( #{placeholders} )"

--- a/gem/lib/pagy/keyset/active_record.rb
+++ b/gem/lib/pagy/keyset/active_record.rb
@@ -10,6 +10,12 @@ class Pagy
       # Get the keyset attributes from the record
       def keyset_attributes_from(record) = record.slice(*@keyset.keys)
 
+      # Get the hash of quoted keyset identifiers
+      def quoted_identifiers(table)
+        connection = @set.connection
+        @keyset.to_h { |column| [column, "#{connection.quote_table_name(table)}.#{connection.quote_column_name(column)}"] }
+      end
+
       # Extract the keyset from the set
       def extract_keyset
         @set.order_values.each_with_object({}) do |node, keyset|

--- a/gem/lib/pagy/keyset/sequel.rb
+++ b/gem/lib/pagy/keyset/sequel.rb
@@ -10,6 +10,12 @@ class Pagy
       # Get the keyset attributes from the record
       def keyset_attributes_from(record) = record.to_hash.slice(*@keyset.keys)
 
+      # Get the hash of quoted keyset identifiersAdd commentMore actions
+      def quoted_identifiers(table)
+        db = @set.db
+        @keyset.to_h { |column| [column, "#{db.quote_identifier(table)}.#{db.quote_identifier(column)}"] }
+      end
+
       # Extract the keyset from the set
       def extract_keyset
         return {} unless @set.opts[:order]


### PR DESCRIPTION
This PR should fix the problem with column names quotes in MySQL introduced by [this commit](https://github.com/ddnexus/pagy/commit/8b7833934d5ba1d9e1767dd5649b1a322bb83072). 

Demo of the problem:
```
irb(main):002> scope = Service.order(id: :desc)
irb(main):003> page = Pagy::Keyset.new(scope, limit: 3000)
irb(main):004> page.records.count
  Service Load (25.3ms)  SELECT `services`.* FROM `services` ORDER BY `services`.`id` DESC LIMIT 3001
irb(main):006> page = Pagy::Keyset.new(scope, limit: 3000, page: page.next)
  Service Load (2.9ms)  SELECT `services`.* FROM `services` /* loading for pp */ ORDER BY `services`.`id` DESC LIMIT 11
=>
#<Pagy::Keyset::ActiveRecord:0x0000000109b270f0
...
irb(main):007> page.records.count
  Service Load (2.3ms)  SELECT `services`.* FROM `services` WHERE (( "services"."id" < '7002' )) ORDER BY `services`.`id` DESC LIMIT 3001
(irb):7:in `<main>': Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '."id" < '7002' )) ORDER BY `services`.`id` DESC LIMIT 3001' at line 1 (ActiveRecord::StatementInvalid)
/Users/alexeyt/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/mysql2-0.5.6/lib/mysql2/client.rb:151:in `_query': You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '."id" < '7002' )) ORDER BY `services`.`id` DESC LIMIT 3001' at line 1 (Mysql2::Error)
```