### PR TITLE
Update aria translation for Tamil (ta) locale

### DIFF
--- a/gem/locales/ta.yml
+++ b/gem/locales/ta.yml
@@ -2,13 +2,9 @@
 ta:
   pagy:
     aria_label:
-      # please add a comment in the https://github.com/ddnexus/pagy/issues/604
-      # posting the translation of the following  "Page"/"Pages" with the plurals for this locale
-      # Please change the final test in 18n_loacles_test.rb to remove the ta.yml exclusion
-      # after you make these changes.
-      nav: "Pages"
-#        one: ""
-#        other: ""
+      nav:
+        one: "பக்கம்"
+        other: "பக்கங்கள்"
       prev: "முந்தையது"
       next: "அடுத்தது"
     prev: "&lt;"

--- a/test/pagy/i18n_locales_test.rb
+++ b/test/pagy/i18n_locales_test.rb
@@ -46,7 +46,7 @@ describe 'pagy/locales' do
       end
     end
     it "ensures #{locale}.yml has the correct aria_label,nav and item_name keys per the declared (#{rule}) rule" do
-      skip if %w[ta sw].include?(locale) # ta.yml and sw.yml do not have the requisite keys yet
+      skip if %w[sw].include?(locale) # sw.yml does not have the requisite keys yet
 
       pluralizations = counts[rule]
 


### PR DESCRIPTION
Closes #604 

I've added the Tamil (ta) translations for the `pagy.aria_label.nav` key. Have updated the test to remove the ta.yml exclusion as well. Please take a look to see if everything is good!