### PR TITLE
Docs: add pagy options exception handling

### DIFF
--- a/docs/guides/how-to.md
+++ b/docs/guides/how-to.md
@@ -369,6 +369,18 @@ def redirect_to_last_page(exception)
 end
 ```
 
+#### Manage `Pagy::OptionError` Exceptions
+
+Similar to managing `Pagy::RangeError` exceptions, bots may attempt to sniff your app by posting questionable page params e.g. `https://some_url&page=password`. This may prove a nuisance if you receive automated emails every time this happens. An alternative solution may be to handle the exception and redirect users to a valid page:
+
+```rb controller
+rescue_from Pagy::OptionError do
+    redirect_to action: :index, params: request.query_parameters.merge(page: 1) # force the first page
+end
+```
+
+Or if you do not wish to redirect, you could simply "Force the `:page`" (please search for this answer above).
+
 !!!warning Rescue from `Pagy::RangeError` first
 
 All Pagy exceptions are subclasses of `ArgumentError`, so if you need to `rescue_from ArgumentError, ...` along with


### PR DESCRIPTION
Sometimes bots spam urls, causing exceptions to be raised, which may trigger emails to be sent, perhaps unnecessarily.

This documents a solution, and is pretty much the same as with handling `RangeErrror` exceptions. 

Full credit to @excid3 for this PR.
