### PR TITLE
Docs: add note re: PRs - which branch for PR to be made against

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 # Pagy Contributions
 
 > [!IMPORTANT]
-> Pagy is imminently moving towards [v43](https://rubygems.org/gems/pagy/versions/43.0.0.rc4). As a result:
-> - Please make PRs to the `master-pre` branch unless you are fixing a bug on the `master` branch.
-> - If the fixes are portable between the `master` and `master-pre` - it would be ideal if two PRs were submitted.
-> - Please raise a discussion re: the above, before starting a PR - because nobody wants to see your work going to waste.
+> Pagy is imminently moving towards [v43](https://ddnexus.github.io/pagy-pre).
+> - Please make PRs to the `master-pre` branch (v43) unless you are fixing a bug on the `master` branch.
+> - If the changes are portable between `master-pre` and `master` it would be ideal if two PRs were submitted.
+> - Please create a [version 43 discussion](https://github.com/ddnexus/pagy/discussions/new?category=version-43) before starting a PR in order to ensure your work will be included.
 
 Pull Requests are welcome!
 
-Here are a few useful information for contributing:
+Here is a little useful information for contributing:
 
-1. If you are planning for a complex PR, we suggest that you check before hand whether your
+1. If you are planning for a complex PR, we suggest that you check beforehand whether your
    proposed changes are going to be accepted by posting your ideas in
    the [Feature Requests](https://github.com/ddnexus/pagy/discussions/categories/feature-requests) discussion area
 2. For adding translations of locale dictionary files please follow
@@ -19,7 +19,7 @@ Here are a few useful information for contributing:
     - Clone pagy: `git clone https://github.com/ddnexus/pagy && cd pagy`
     - [Configure the git-hooks](https://github.com/ddnexus/pagy/tree/master/scripts/hooks)
 4. **Development**
-    - Please create your own branch out of `master` and use it for you development and PR
+    - Please create your own branch out of `master` and use it for your development and PR
     - Ensure you are basing your PR on the `master` branch and keep rebasing it on `master` when it changes
     - **Code**
        - You can have a decent development environment already setup by just using one of the apps in

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,35 +1,8 @@
-<!--- Provide a general summary of your changes in the Title above -->
+> [!IMPORTANT]
+> Pagy is imminently moving towards [v43](https://ddnexus.github.io/pagy-pre).
+> - Please make PRs to the `master-pre` branch (v43) unless you are fixing a bug on the `master` branch.
+> - If the changes are portable between `master-pre` and `master` it would be ideal if two PRs were submitted.
+> - Please create a [version 43 discussion](https://github.com/ddnexus/pagy/discussions/new?category=version-43) before starting a PR to ensure your work will be included.
 
-## Description
-<!--- Describe your changes in detail -->
-
-## Related Issue
-<!--- This project only accepts pull requests related to open issues -->
-<!--- If suggesting a new feature or change, please open a discussion first  -->
-<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
-<!--- Please link to the issue here: -->
-
-## Motivation and Context
-<!--- Why is this change required? What problem does it solve? -->
-<!--- If it fixes an open issue, please link to the issue here. -->
-
-## Which Branch?
-
-<!---
-
-PR, explaining that all PR should be against the master-pre branch, UNLESS they explicitly fix a specific problem of the (almost legacy) master. Ideally, if possible and portable between old and new, we would need 2 PRs for both branches, if that applies.
-
-There are two "versions" of pagy: 
-
-1. the "legacy" version on `master` branch and
-2. the pagy 43 version on the `master-pre` branch.
-
-
-- All PRs should be made against the `master-pre` branch.
-- ... unless the PR fixes an issue with the (legacy) `master` branch. If that's the case, then please see if you can make two PRs (on both the `master` and `master-pre` branches) - with portable changes between the two branches.
-
--->
-
-## Contributions
-
-<!--- List contributors here -->
+> [!TIP]
+> See also [Contributing](https://github.com/ddnexus/pagy/blob/master/.github/CONTRIBUTING.md) for details.


### PR DESCRIPTION
## Summary

- note re PRs - on which branch they should be made.
- add a pull request template

## Description

- There are two separate versions of Pagy: the `master` and version `43`.
- This adds a note suggesting where to make a PR.
- Further, it alerts users (who may not know) that there IS a version 43.

## Motivation and Context

- The change is required because there are two versions of pagy which need to be maintained at the moment.
- It would be ideal if bug fixes are made on both versions at the same time.
- This PR attempts to solve that problem

## Which Branch?
- this PR should be made against both the `master` and `master-pre`

## Contributions

@ddnexus 

