### PR TITLE
Link to documentation website's CHANGELOG page

### DIFF
--- a/gem/pagy.gemspec
+++ b/gem/pagy.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
                     'homepage_uri'          => 'https://github.com/ddnexus/pagy',
                     'documentation_uri'     => 'https://ddnexus.github.io/pagy',
                     'bug_tracker_uri'       => 'https://github.com/ddnexus/pagy/issues',
-                    'changelog_uri'         => 'https://github.com/ddnexus/pagy/blob/master/CHANGELOG.md',
+                    'changelog_uri'         => 'https://ddnexus.github.io/pagy/changelog/',
                     'support'               => 'https://github.com/ddnexus/pagy/discussions/categories/q-a' }
   s.executables << 'pagy'
   s.add_dependency 'json'


### PR DESCRIPTION
The existing `changelog_uri` URL is linked from this gem's page on RubyGems.org and results in a 404. The change here links to the documentation website's CHANGELOG page.

Other options for `changelog_uri`:

- https://github.com/ddnexus/pagy/releases (either the main page or the current version)
- https://github.com/ddnexus/pagy/blob/master/docs/CHANGELOG.md

