### PR TITLE
Allow passing nested `page_key` param

### DIFF
--- a/gem/lib/pagy/classes/request.rb
+++ b/gem/lib/pagy/classes/request.rb
@@ -20,7 +20,7 @@ class Pagy
 
     def resolve_page(options, force_integer: true)
       page_key = options[:page_key] || DEFAULT[:page_key]
-      page     = @jsonapi ? @params['page'][page_key] : @params[page_key]
+      page     = @jsonapi ? @params['page'][page_key] : @params.dig(*page_key)
       page     = nil if page == ''   # fix for app-generated queries like ?page=
       force_integer ? (page || 1).to_i : page
     end


### PR DESCRIPTION
This PR enables support for nested page keys in paginated requests, allowing multiple paginated resources to coexist on the same page with distinct pagination state.

When rendering multiple paginated collections on a single page, I needed a way to namespace pagination parameters to avoid conflicts. For example, on a dashboard displaying both paginated posts and paginated users, we need separate pagination controls for each collection (eg: `{ posts: { author_id: 123, page: 4 }, users: { page: 5 } }`)

This PR allows passing `page_key` as an array (e.g., `["posts", "page"]`) to access nested pagination parameters. This enables the paginator to read from `params[:posts][:page]` instead of the default `params[:page]`.