### PR TITLE
Fix `root_key` nested params mutation in `compose_page_url` 

### DIFF
--- a/gem/lib/pagy/modules/abilities/linkable.rb
+++ b/gem/lib/pagy/modules/abilities/linkable.rb
@@ -48,7 +48,7 @@ class Pagy
                 .values_at(:root_key, :page_key, :limit_key, :client_max_limit, :limit, :querify, :absolute, :path, :fragment)
       params = @request.params.clone(freeze: false)
       # Deep clone nested params to prevent modifying the original request params when using root_key
-      params[root_key] = params[root_key]&.then { |h| h.respond_to?(:deep_dup) ? h.deep_dup : h.dup } if root_key
+      params[root_key] = params[root_key]&.then { |h| deep_dup_value(h) } if root_key
       (root_key ? params[root_key] ||= {} : params).tap do |h|
         { page_key  => compose_page_param(page),
           limit_key => client_max_limit && limit }.each { |k, v| v ? h[k] = v : h.delete(k) }
@@ -57,6 +57,12 @@ class Pagy
       query_string = QueryUtils.build_nested_query(params).sub(/\A(?=.)/, '?')
       fragment   &&= "##{fragment.delete_prefix('#')}"
       "#{@request.base_url if absolute}#{path || @request.path}#{query_string}#{fragment}"
+    end
+
+    private
+
+    def deep_dup_value(obj)
+      obj.is_a?(Hash) ? obj.transform_values { |v| deep_dup_value(v) } : obj
     end
   end
 end


### PR DESCRIPTION
## Problem
Run into a bug when using the new `root_key` option. After page refresh on a URL with multiple nested keys like `/posts?articles[page]=1&news[page]=3` the pagination links were generated with `[page]=P ` (the `PAGE_TOKEN` placeholder) instead of the actual page numbers. 

## Root cause 
The `compose_page_url` method is using a shallow clone of request params:

```ruby
params = @request.params.clone(freeze: false)
```

so nested hashes (`params[root_key]`) still reference the original. When the method later modifies these nested hashes with `h[k] = v`, it is inadvertently modifying the original request params.

## Solution
Added deep cloning of nested params before modification:
```ruby
params[root_key] = params[root_key]&.then { |h| deep_dup_value(h) } if root_key
```

Now modifications only affect the local copy, preserving the original request params for subsequent operations.