### PR TITLE
Fix keyset error caused by the change of resolve_page

### DIFF
--- a/gem/lib/pagy/classes/keyset/keyset.rb
+++ b/gem/lib/pagy/classes/keyset/keyset.rb
@@ -82,7 +82,7 @@ class Pagy
     def keyset? = true
 
     def assign_page
-      return unless (@page = @options[:page])
+      return unless @options[:page] != '' && (@page = @options[:page])
 
       @prior_cutoff = JSON.parse(B64.urlsafe_decode(@page))
     end

--- a/test/pagy/classes/keyset/keyset_test.rb
+++ b/test/pagy/classes/keyset/keyset_test.rb
@@ -34,6 +34,10 @@ describe "Pagy Keyset" do
           # returns a subclass instance, which is_a? Pagy::Keyset
           _(Pagy::Keyset.new(model.order(:id))).must_be_kind_of Pagy::Keyset
         end
+
+        it 'is an instance of Pagy::Keyset if page is empty string' do
+          _(Pagy::Keyset.new(model.order(:id), page: '')).must_be_kind_of Pagy::Keyset
+        end
       end
 
       describe 'uses optional options' do


### PR DESCRIPTION
Thank your for your great gem.

[This commit](https://github.com/ddnexus/pagy/commit/f859166c8cbb9d651ffb091e00337a501116c657) raises exception on keyset pagination.

It changes `@options[:page]` from `nil` to `''`, so JSON.parse raises exception.

> [!TIP]
> See also [Contributing](https://github.com/ddnexus/pagy/blob/master/.github/CONTRIBUTING.md) for details.
