### PR TITLE
Fix NoMethodError with tampered params

### DIFF
--- a/gem/lib/pagy/classes/request.rb
+++ b/gem/lib/pagy/classes/request.rb
@@ -21,7 +21,7 @@ class Pagy
     def resolve_page(force_integer: true)
       page_key = @options[:page_key] || DEFAULT[:page_key]
       page     = @params.dig(@options[:root_key], page_key) || @params[page_key]
-      return [page.to_i, 1].max if force_integer
+      return [page.to_s.to_i, 1].max if force_integer
 
       page unless page == ''
     end


### PR DESCRIPTION
I've had some requests come in that are clearly messing with params such as `?page[]=2` and `?page[testing]=1`

This causes an error when casting `to_i` here since page is an Array or Hash and not a String. 
https://github.com/ddnexus/pagy/blob/53f6bbb7859b40bd6b54f0ccff90d6381a0aa3fa/gem/lib/pagy/classes/request.rb#L24

It raises a `NoMethodError` which isn't ideal to rescue from in a controller.

By casting to a String, this will fix the issue and return 0 when an invalid value is found since:

```ruby
["2"].to_s.to_i #=> 0
{"testing" => "1"}.to_s.to_i #=> 0
```

This should make Pagy raise a lot less errors when the page param is tampered with by bots or malicious users.