### PR TITLE
Add test and fix empty aria label issue

### DIFF
--- a/gem/lib/pagy/toolbox/helpers/support/nav_aria_label_attribute.rb
+++ b/gem/lib/pagy/toolbox/helpers/support/nav_aria_label_attribute.rb
@@ -5,7 +5,8 @@ class Pagy
   private
 
   # Compose the aria label attribute for the nav
-  def nav_aria_label_attribute(aria_label: I18n.translate('pagy.aria_label.nav', count: @last))
+  def nav_aria_label_attribute(aria_label: nil)
+    aria_label ||= I18n.translate('pagy.aria_label.nav', count: @last)
     %(aria-label="#{aria_label}")
   end
 end

--- a/test/unit/pagy/toolbox/helpers/support/nav_aria_label_attribute_test.rb
+++ b/test/unit/pagy/toolbox/helpers/support/nav_aria_label_attribute_test.rb
@@ -23,6 +23,11 @@ describe 'Pagy#nav_aria_label_attribute' do
     _(pagy.nav_aria_label_attribute).must_equal 'aria-label="Pages"'
   end
 
+  it 'falls back to I18n default when aria_label is explicitly nil' do
+    pagy = pagy_class.new(last: 5)
+    _(pagy.nav_aria_label_attribute(aria_label: nil)).must_equal 'aria-label="Pages"'
+  end
+
   it 'uses provided aria_label' do
     pagy = pagy_class.new
     _(pagy.nav_aria_label_attribute(aria_label: 'Custom Nav')).must_equal 'aria-label="Custom Nav"'


### PR DESCRIPTION
Starting in version 43.2.7, the aria label is blank when it is not explicitly overridden. I tracked it down to [this change](https://github.com/ddnexus/pagy/commit/eb7607df605ec359a5f282a9dc8b12184d66f511#diff-7ddc38c99a8b2ddd9a06b4942e648e88a0f6bbe21f86d00f336140b67a158632R8) which moves the default from within the method to the keyword argument default.

However, uses of this method [such as here](https://github.com/ddnexus/pagy/blob/eb7607df605ec359a5f282a9dc8b12184d66f511/gem/lib/pagy/toolbox/helpers/support/wrap_series_nav.rb#L16) explicitly pass a value that might be nil. Thus, the nil value overrides the keyword argument default and the aria label is empty.