### PR TITLE
Fix missing bracket in series_nav_js documentation

### DIFF
--- a/docs/toolbox/helpers/series_nav_js.md
+++ b/docs/toolbox/helpers/series_nav_js.md
@@ -65,7 +65,7 @@ categories:
 !!!
 
 ```erb
-<%== @pagy.series_nav_js(**options %>  <%# default pagy style %>
+<%== @pagy.series_nav_js(**options) %>  <%# default pagy style %>
 <%== @pagy.series_nav_js(:bootstrap, **options) %>
 <%== @pagy.series_nav_js(:bulma, **options) %>
 ```


### PR DESCRIPTION
Surely the pinnacle of my career. Adds a missing bracket in the docs for series_nav_js which caught me out when I blindly copy pasted the example :flushed: 