### PR TITLE
test(paginator): add typesense_rails paginator unit coverage

### DIFF
--- a/test/unit/mocks/typesense_rails.rb
+++ b/test/unit/mocks/typesense_rails.rb
@@ -1,0 +1,44 @@
+
+# frozen_string_literal: true
+
+require 'pagy/classes/offset/search'
+
+module MockTypesenseRails
+  RESULTS = {
+    '*' => (1..1000).map { |n| "doc-#{n}" },
+    'a' => (1..1000).map { |n| "a-#{n}" },
+    'b' => (1..1000).map { |n| "b-#{n}" }
+  }.freeze
+
+  class Results
+    attr_reader :term, :options
+
+    def initialize(term, options = {})
+      @term    = term
+      @options = options
+      @page    = options[:page] || 1
+      @limit   = options[:per_page] || 20
+    end
+
+    def raw_answer
+      all_results = RESULTS[@term] || []
+      offset      = (@page - 1) * @limit
+      hits        = all_results[offset, @limit] || []
+
+      {
+        'found'          => all_results.size,
+        'page'           => @page,
+        'request_params' => { 'per_page' => @limit },
+        'hits'           => hits
+      }
+    end
+  end
+
+  class Model
+    extend Pagy::Search
+
+    def self.search(term, _query_by = nil, options = {})
+      Results.new(term, options)
+    end
+  end
+end

--- a/test/unit/pagy/toolbox/paginators/typesense_rails_test.rb
+++ b/test/unit/pagy/toolbox/paginators/typesense_rails_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'unit/test_helper'
+require 'pagy/toolbox/paginators/typesense_rails'
+require 'mocks/app'
+require 'mocks/typesense_rails'
+
+describe 'Pagy::TypesenseRailsPaginator' do
+  let(:app) { MockApp.new }
+
+  describe '#paginate' do
+    describe 'Active Mode (pagy_search)' do
+      it 'paginates with defaults' do
+        args = MockTypesenseRails::Model.pagy_search('a', 'name')
+
+        pagy, results = app.pagy(:typesense_rails, args, page: 1, limit: 10)
+
+        _(pagy).must_be_kind_of Pagy::TypesenseRails
+        _(pagy.count).must_equal 1000
+        _(pagy.page).must_equal 1
+        _(pagy.limit).must_equal 10
+        _(results).must_be_kind_of MockTypesenseRails::Results
+        _(results.raw_answer['hits'].first).must_equal 'a-1'
+        _(results.raw_answer['hits'].size).must_equal 10
+      end
+
+      it 'paginates with custom options' do
+        args = MockTypesenseRails::Model.pagy_search('b', 'name')
+
+        pagy, results = app.pagy(:typesense_rails, args, page: 2, limit: 20)
+
+        _(pagy.page).must_equal 2
+        _(pagy.limit).must_equal 20
+        _(results.raw_answer['page']).must_equal 2
+        _(results.raw_answer['hits'].first).must_equal 'b-21'
+        _(results.raw_answer['hits'].last).must_equal 'b-40'
+      end
+    end
+
+    describe 'Passive Mode (Results object)' do
+      it 'paginates from existing results' do
+        results = MockTypesenseRails::Results.new('a', page: 3, per_page: 15)
+
+        pagy = app.pagy(:typesense_rails, results)
+
+        _(pagy).must_be_kind_of Pagy::TypesenseRails
+        _(pagy.page).must_equal 3
+        _(pagy.limit).must_equal 15
+        _(pagy.count).must_equal 1000
+      end
+    end
+  end
+end


### PR DESCRIPTION
- add a typesense rails mock model/results to simulate pagy_search and raw_answer pagination behavior
- add unit tests for active mode and passive mode pagination paths in the typesense_rails paginator

- link to  https://github.com/typesense/typesense-rails/issues/17#issuecomment-3935226410
