### PR TITLE
Docs: add OSS community key to retype action to unlock pro features

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -46,11 +46,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: retypeapp/action-build@latest
+        env:
+          RETYPE_KEY: ${{ secrets.RETYPE_KEY }}
         with:
           config_path: docs/
+
 
       - uses: retypeapp/action-github-pages@latest
         with:
           branch: docsite
           update-branch: true
-          


### PR DESCRIPTION
### What is this?

We wanna use retype's OSS key "community key" to unlock pro features.

In order to do that, we had to make a small change to take advantage of that key (via a github action). This PR makes that possible. Also, I have manually added the key to the ddnexus/pagy repository. I have tested this on benkoshy/pagy - and the docs site gets published. But I am still not yet sure whether the PRO features are unlocked. I'm going to assume that they are.

References:

- Retype Environment Variable used (https://retype.com/guides/key-setup/)
- https://retype.com/community/- 