### PR TITLE
Fix #page_url duplicating query params when page_key is a symbol

### DIFF
--- a/gem/lib/pagy/modules/abilities/linkable.rb
+++ b/gem/lib/pagy/modules/abilities/linkable.rb
@@ -52,8 +52,8 @@ class Pagy
                     params
                   end
 
-      { opts[:page_key]  => compose_page_param(page),
-        opts[:limit_key] => opts[:max_limit] && opts[:limit] }.each do |k, v|
+      { opts[:page_key].to_s  => compose_page_param(page),
+        opts[:limit_key].to_s => opts[:max_limit] && opts[:limit] }.each do |k, v|
         v ? container[k] = v : container.delete(k)
       end
 

--- a/test/unit/pagy/modules/abilities/linkable_test.rb
+++ b/test/unit/pagy/modules/abilities/linkable_test.rb
@@ -148,5 +148,19 @@ describe 'Pagy::Linkable Specs' do
       url = subject.call_compose_page_url(2)
       _(url).must_equal_url '/foo?limit=10&page=2'
     end
+
+    it 'does not duplicate params when page_key is a symbol' do
+      subject = linkable_class.new(request_params: { 'page' => '1' },
+                                   options:        { page_key: :page })
+      url = subject.call_compose_page_url(2)
+      _(url).must_equal_url '/foo?page=2'
+    end
+
+    it 'does not duplicate params when limit_key is a symbol' do
+      subject = linkable_class.new(request_params: { 'limit' => '10' },
+                                   options:        { limit_key: :limit, max_limit: 50, limit: 20 })
+      url = subject.call_compose_page_url(2)
+      _(url).must_equal_url '/foo?limit=20&page=2'
+    end
   end
 end


### PR DESCRIPTION
`Pagy::Request#get_params` stores request params as a plain string-keyed hash. A symbol `page_key` / `limit_key` passed through options would write a sibling symbol entry alongside the existing string key, emitting duplicate pairs in the query string. Coerce both keys to string in `Linkable#compose_page_url` so the container is always updated in place.

Closes #848.