### PR TITLE
Fix broken API Test badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <span>[![Gem Version](https://img.shields.io/gem/v/pagy.svg?label=Pagy&labelColor=1f7a1f&color=2aa22a)](https://rubygems.org/gems/pagy)</span> <span>
 [![Supported Rubies](https://img.shields.io/badge/Ruby-EOL-ruby.svg?colorA=99004d&colorB=cc0066)](https://endoflife.date/ruby)</span> <span>
-[![UnitTest](https://github.com/ddnexus/pagy/actions/workflows/unit-test.yml/badge.svg?branch=master)](https://github.com/ddnexus/pagy/actions/workflows/ruby-test.yml)</span> <span>
+[![API Test](https://github.com/ddnexus/pagy/actions/workflows/api-test.yml/badge.svg?branch=master)](https://github.com/ddnexus/pagy/actions/workflows/api-test.yml)</span> <span>
 [![E2E Test](https://github.com/ddnexus/pagy/actions/workflows/e2e-test.yml/badge.svg?branch=master)](https://github.com/ddnexus/pagy/actions/workflows/e2e-test.yml)</span> <span>
 ![Coverage](https://img.shields.io/badge/Coverage-100%25-coverage.svg?colorA=1f7a1f&colorB=2aa22a)</span> <span>
 ![Rubocop Status](https://img.shields.io/badge/Rubocop-passing-rubocop.svg?colorA=1f7a1f&colorB=2aa22a)</span> <span>


### PR DESCRIPTION
The "UnitTest" badge in `README.md` is broken: the image URL points to `unit-test.yml` and the link URL points to `ruby-test.yml`, neither of which exists anymore.

The workflow has been renamed twice:
| Date | Commit | Rename |
|---|---|---|
| 2026-02-13 | b1eee71e6 | `ruby-test.yml` → `unit-test.yml` |
| 2026-04-07 | ec87ff939 | `unit-test.yml` → `api-test.yml` |

## Changes

Update both URLs to `api-test.yml` and align the label with the workflow's `name:` ("API Test").