### PR TITLE
fix(docs): fix input_nav_js link text in how-to guide

### DIFF
--- a/docs/guides/how-to.md
+++ b/docs/guides/how-to.md
@@ -351,7 +351,7 @@ Unlike other gems, Pagy does not decide for you that the nav of a single page of
   - [:keynav_js](/toolbox/paginators/keynav_js)
 - Consider the  helpers:
   - [series_nav_js](/toolbox/helpers/series_nav_js)
-  - [series_nav_js](/toolbox/helpers/input_nav_js)
+  - [input_nav_js](/toolbox/helpers/input_nav_js)
 - When possible
   - [Paginate only MAX records](#paginate-only-max-records)
 


### PR DESCRIPTION
## Description
Fix a documentation typo where the link text for `input_nav_js` helper was incorrectly showing as `series_nav_js`, creating confusion in the how-to guide.

## Changes
- [docs/guides/how-to.md](docs/guides/how-to.md#L354): Updated link text from `series_nav_js` to `input_nav_js` in the "Consider the helpers" section

## Impact
This corrects a documentation error that could lead users to the wrong helper documentation when reading the how-to guide.