### PR TITLE
Add a real rake test task for the unit suite

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,13 @@
 # frozen_string_literal: true
 
+require 'bundler/setup'
+
 Rake.add_rakelib 'tasks'
+
+desc 'Run the unit test suite'
+task :test do
+  script = 'Dir.glob("test/unit/**/*_test.rb").sort.each { |f| require "./" + f }'
+  sh Gem.ruby, '-Igem/lib:test', '-e', script
+end
+
+task default: :test


### PR DESCRIPTION
- The root [Rakefile:1-12] previously only loaded the Thor tasks, so [rake test] completed without running any tests.

- Added Bundler setup and a dedicated [test] task that executes the full unit suite under [gem/lib:test].

- Set [test] as the default Rake task so the conventional command now behaves as expected.
- Verified the change by running [rake test] the full suite passes with 562 tests and 0 failures.