### PR TITLE
Validate I18n locale input, coerce dev_tools wand_scale, add input-safety docs

### DIFF
--- a/docs/guides/how-to.md
+++ b/docs/guides/how-to.md
@@ -44,6 +44,10 @@ Pagy retrieves the page from the `'page'` request params hash. To force a specif
 @pagy, @records = pagy(:offset, collection, page: 3) # force page #3
 ```
 
+==- Handle user input
+
+See [Safety](/guides/safety)
+
 ==- Customize the ARIA labels
 
 You can customize the `aria-label` attributes of any `*nav*` helper by providing a `:aria_label` string.

--- a/docs/guides/safety.md
+++ b/docs/guides/safety.md
@@ -1,0 +1,21 @@
+---
+label: "Safety"
+icon: shield
+order: 98
+---
+
+#
+
+## :icon-shield:&nbsp;&nbsp;Safety
+
+---
+
+!!!success
+
+Pagy handles the input of **its own URL params safely**, and assumes that all the configuration, options and arguments you set in your code are safe to use verbatim in its helpers.
+
+!!!warning WARNING!
+
+If you use **any other raw end-user input** into your Pagy configuration, options, or arguments, you must sanitize or escape it first in your own code.
+
+!!!

--- a/gem/lib/pagy/modules/abilities/configurable.rb
+++ b/gem/lib/pagy/modules/abilities/configurable.rb
@@ -12,13 +12,16 @@ class Pagy
       FileUtils.cp(files, destination)
     end
 
-    # Generate the script and style tags to help development
+    # Generate the script and style tags to help development.
+    # wand_scale is coerced with to_f: wand.js reads data-scale via parseFloat
+    # and multiplies it into rem sizes, so fractional scales are meaningful;
+    # the coercion also neutralizes any non-numeric string passed in.
     def dev_tools(wand_scale: 1)
       <<~HTML
         <script id="pagy-ai-widget">
           #{ROOT.join('javascripts/ai_widget.js').read}
         </script>
-        <script id="pagy-wand" data-scale="#{wand_scale}">
+        <script id="pagy-wand" data-scale="#{wand_scale.to_f}">
           #{ROOT.join('javascripts/wand.js').read}
         </script>
         <style id="pagy-wand-default">

--- a/gem/lib/pagy/modules/abilities/configurable.rb
+++ b/gem/lib/pagy/modules/abilities/configurable.rb
@@ -13,9 +13,6 @@ class Pagy
     end
 
     # Generate the script and style tags to help development.
-    # wand_scale is coerced with to_f: wand.js reads data-scale via parseFloat
-    # and multiplies it into rem sizes, so fractional scales are meaningful;
-    # the coercion also neutralizes any non-numeric string passed in.
     def dev_tools(wand_scale: 1)
       <<~HTML
         <script id="pagy-ai-widget">

--- a/gem/lib/pagy/modules/i18n/i18n.rb
+++ b/gem/lib/pagy/modules/i18n/i18n.rb
@@ -8,8 +8,7 @@ class Pagy
   module I18n
     class KeyError < KeyError; end
 
-    # BCP 47-shaped locale (matches all the gem/locales/*.yml names, e.g. en, ckb, pt-BR, sv-SE).
-    # Used to reject anything that could be used as a path component in the locale file lookup.
+    # Match only valid locale names. (See https://www.rfc-editor.org/info/rfc4647/)
     LOCALE_PATTERN = /\A[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*\z/
 
     extend self
@@ -22,10 +21,7 @@ class Pagy
       @locales ||= {}
     end
 
-    # Store the variable for the duration of a single request.
-    # value.to_s[LOCALE_PATTERN] keeps a valid locale, and stores nil for both
-    # nil (reset to the default) and any invalid/path-like string, which then
-    # falls back to the default locale without raising or logging.
+    # Set a valid locale or nil for the duration of a single request. Avoid errors/logging.
     def locale=(value)
       Thread.current[:pagy_locale] = value.to_s[LOCALE_PATTERN]
     end

--- a/gem/lib/pagy/modules/i18n/i18n.rb
+++ b/gem/lib/pagy/modules/i18n/i18n.rb
@@ -8,6 +8,10 @@ class Pagy
   module I18n
     class KeyError < KeyError; end
 
+    # BCP 47-shaped locale (matches all the gem/locales/*.yml names, e.g. en, ckb, pt-BR, sv-SE).
+    # Used to reject anything that could be used as a path component in the locale file lookup.
+    LOCALE_PATTERN = /\A[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*\z/
+
     extend self
 
     def pathnames
@@ -18,9 +22,12 @@ class Pagy
       @locales ||= {}
     end
 
-    # Store the variable for the duration of a single request
+    # Store the variable for the duration of a single request.
+    # value.to_s[LOCALE_PATTERN] keeps a valid locale, and stores nil for both
+    # nil (reset to the default) and any invalid/path-like string, which then
+    # falls back to the default locale without raising or logging.
     def locale=(value)
-      Thread.current[:pagy_locale] = value.to_s
+      Thread.current[:pagy_locale] = value.to_s[LOCALE_PATTERN]
     end
 
     def locale

--- a/src/wand.ts
+++ b/src/wand.ts
@@ -708,7 +708,7 @@ document.addEventListener('DOMContentLoaded', async () => {
               <dt>Add this line in your HTML head</dt>
               <dd>
                 <p><code><%== Pagy.dev_tools %></code></p>
-                <p>You can pass the optional <code>wand_scale</code> argument to change the size of the Wand.
+                <p>You can pass the optional <code>wand_scale</code> (fractional) argument to change the size of the Wand.
                   <br>Default: <code>wand_scale: 1</code></p>
               </dd>
             </dl>

--- a/test/unit/pagy/modules/abilities/configurable_test.rb
+++ b/test/unit/pagy/modules/abilities/configurable_test.rb
@@ -61,19 +61,26 @@ describe 'Pagy::Configurable Specs' do
     it 'generates the wand tag with default scale' do
       generated_html = Pagy.dev_tools # scale: 1 is default
 
-      # Check script tag structure and content using regex for flexibility with whitespace
-      _(generated_html).must_match %r{<script id="pagy-wand" data-scale="1">\s*#{Regexp.escape(js_content)}\s*</script>}m
+      # Default Integer 1 is coerced to 1.0 by to_f (parseFloat("1.0") === 1 client-side)
+      _(generated_html).must_match %r{<script id="pagy-wand" data-scale="1\.0">\s*#{Regexp.escape(js_content)}\s*</script>}m
       # Check style tag structure and content using regex
       _(generated_html).must_match %r{<style id="pagy-wand-default">\s*#{Regexp.escape(css_content)}\s*</style>}m
     end
 
-    it 'generates the wand tag with custom scale' do
+    it 'generates the wand tag with custom fractional scale' do
       generated_html = Pagy.dev_tools(wand_scale: 2.5)
 
-      # Check script tag structure and content with custom scale
+      # Fractional scale is preserved (to_f, not to_i)
       _(generated_html).must_match %r{<script id="pagy-wand" data-scale="2\.5">\s*#{Regexp.escape(js_content)}\s*</script>}m
-      # Check style tag structure and content (should be the same)
       _(generated_html).must_match %r{<style id="pagy-wand-default">\s*#{Regexp.escape(css_content)}\s*</style>}m
+    end
+
+    it 'neutralizes a non-numeric wand_scale (no attribute injection)' do
+      generated_html = Pagy.dev_tools(wand_scale: %(1"></script><script>alert(1)</script>))
+
+      # to_f stops at the first non-numeric char: the payload collapses to 1.0
+      _(generated_html).must_match(/<script id="pagy-wand" data-scale="1\.0">/)
+      _(generated_html).wont_include '<script>alert(1)</script>'
     end
   end
 

--- a/test/unit/pagy/modules/abilities/configurable_test.rb.yaml
+++ b/test/unit/pagy/modules/abilities/configurable_test.rb.yaml
@@ -1,9 +1,9 @@
 ---
-L120-a59b2f94b9210b48:
+L127-a59b2f94b9210b48:
 - <span class="pagy info">No items found</span>
-L121-8fe9d1768c36def9:
+L128-8fe9d1768c36def9:
 - <span class="pagy info">Displaying 1 item</span>
-L122-9481598b601e2742:
+L129-9481598b601e2742:
 - <span class="pagy info">Displaying 13 items</span>
-L123-b00c8dc1bdeaf1ec:
+L130-b00c8dc1bdeaf1ec:
 - <span class="pagy info">Displaying items 41-60 of 100 in total</span>

--- a/test/unit/pagy/modules/i18n/i18n_test.rb
+++ b/test/unit/pagy/modules/i18n/i18n_test.rb
@@ -47,6 +47,21 @@ describe 'Pagy::I18n Specs' do
     it 'has default pathnames' do
       _(i18n.pathnames).must_include Pagy::ROOT.join('locales')
     end
+
+    it 'accepts BCP 47 shaped locales' do
+      i18n.locale = 'pt-BR'
+      _(i18n.locale).must_equal 'pt-BR'
+
+      i18n.locale = 'zh-Hant-CN'
+      _(i18n.locale).must_equal 'zh-Hant-CN'
+    end
+
+    it 'silently falls back to the default for invalid or path-like locales' do
+      ['/etc/passwd', '../../config/secrets', 'en_US', 'en;rm', ''].each do |bad|
+        i18n.locale = bad
+        _(i18n.locale).must_equal 'en' # stored as nil, getter returns the default
+      end
+    end
   end
 
   describe 'translation logic' do
@@ -118,9 +133,9 @@ describe 'Pagy::I18n Specs' do
     it 'falls back to en using cached locale' do
       i18n.locale = 'en'
       i18n.translate('pagy.item_name', count: 1)
-      i18n.locale = 'unknown_cached'
+      i18n.locale = 'zz' # valid BCP 47 shape, but no zz.yml dictionary
       _out, err = capture_io { _(i18n.translate('pagy.item_name', count: 1)).must_equal 'item' }
-      _(err).must_match 'Pagy::I18n: missing dictionary file for "unknown_cached" locale; using "en" instead'
+      _(err).must_match 'Pagy::I18n: missing dictionary file for "zz" locale; using "en" instead'
     end
 
     it 'raises error for missing pagy key' do
@@ -131,10 +146,10 @@ describe 'Pagy::I18n Specs' do
     end
 
     it 'raises error for missing p11n key' do
-      File.write(File.join(tmp_dir, 'broken_p11n.yml'), "broken_p11n:\n  pagy:\n    key: 'val'")
-      i18n.locale = 'broken_p11n'
+      File.write(File.join(tmp_dir, 'badp.yml'), "badp:\n  pagy:\n    key: 'val'")
+      i18n.locale = 'badp'
       err = _ { i18n.translate('foo') }.must_raise Pagy::I18n::KeyError
-      _(err.message).must_match "missing 'p11n' key in \"broken_p11n\" locale"
+      _(err.message).must_match "missing 'p11n' key in \"badp\" locale"
     end
 
     it 'caches loaded locales' do


### PR DESCRIPTION
## Summary

Hardening of two caller-facing inputs plus the accompanying safety docs,
developed together with @ddnexus.

- **I18n locale**: `Pagy::I18n.locale=` now keeps only BCP 47-shaped
  values (`LOCALE_PATTERN`); anything else — including `nil` — resolves
  to the default locale instead of being used verbatim in the
  locale-file lookup. Nothing is raised, so it can't be used to flood
  the logs either.

- **dev_tools wand_scale**: coerced with `to_f` before it reaches the
  generated `data-scale` attribute. `wand.js` reads it via `parseFloat`,
  so fractional scales are preserved while any non-numeric input simply
  collapses to a number.

- **Docs**: new `guides/safety.md` (and a pointer from `how-to.md`)
  stating that Pagy handles its own URL params safely and trusts the
  arguments the application passes to its helpers — any other raw
  end-user input must be sanitized/escaped by the app first.

## Tests

- `bundle exec thor test:api:all` — green (current + next API)
- `bundle exec rubocop` — no offenses

Branch is rebased on the latest `dev`, so it should merge cleanly.
