### PR TITLE
Chore: url override to github actions

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -43,6 +43,7 @@ jobs:
           RETYPE_KEY: ${{ secrets.RETYPE_KEY }}
         with:
           config_path: docs/
+          override: '{"url": "https://${{github.actor}}.github.io/pagy/"}'
 
       - uses: retypeapp/action-github-pages@latest
         with:


### PR DESCRIPTION
Why?

So anyone who contributes to the docs can test it "locally", with their own deployed version on their own github url e.g. benkoshy.githbub.io/pagy, prior to making a PR to the upstream repository.

The genesis was issue https://github.com/ddnexus/pagy/issues/913 I wanted to test a change to the docs on my own deployed version: benkoshy.github.io/pagy.

I could not do so unless i set the retype URL to my own account benkoshy.github.io. But doing so would affect the deployment at ddnexus.github.io.

The solution is to override the url, which allows the benkoshy built docs to work  without affecting ddexus.github.io/pagy

Check out my docs here: https://benkoshy.github.io/pagy/
